### PR TITLE
fix: app closing on drag

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { DragHandle } from './components/DragHandle'
 import { EmojiPicker } from './components/EmojiPicker'
 import { GifPicker } from './components/GifPicker'
 import type { ActiveTab } from './types/clipboard'
+import { invoke } from '@tauri-apps/api/core'
 
 /**
  * Main App Component - Windows 11 Clipboard History Manager
@@ -43,6 +44,14 @@ function App() {
   const handleTabChange = useCallback((tab: ActiveTab) => {
     setActiveTab(tab)
   }, [])
+
+  const handleMouseEnter = () => {
+    invoke('set_mouse_state', { inside: true }).catch(console.error)
+  }
+
+  const handleMouseLeave = () => {
+    invoke('set_mouse_state', { inside: false }).catch(console.error)
+  }
 
   // Render content based on active tab
   const renderContent = () => {
@@ -105,6 +114,8 @@ function App() {
         // Text color based on theme
         isDark ? 'text-win11-text-primary' : 'text-win11Light-text-primary'
       )}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
     >
       {/* Drag Handle */}
       <DragHandle />


### PR DESCRIPTION
## 📝 Description
The app was closing on drag

## 🧪 Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Chore (build process, dependencies, etc.)

## ✅ Checklist
- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format`
- [x] I have tested my changes locally
- [x] I have added/updated documentation as needed
- [x] My changes don't introduce new warnings
- [x] I have tested on both X11 and Wayland (if applicable)

## 🖥️ Testing Environment

- **OS**: Ubuntu
- **Desktop Environment**: Gnome 
- **Display Server**: X11

## Summary by Sourcery

Prevent the application window from closing when the user drags within the app content area by tracking mouse presence and suppressing hide-on-blur in that case.

Bug Fixes:
- Track whether the mouse cursor is inside the app window and avoid hiding the window on focus loss while the cursor is inside.
- Expose a Tauri command and wire React mouse enter/leave handlers so the frontend can update the backend mouse state during window interactions.