### PR TITLE
refactor: arrow navigation

### DIFF
--- a/src/ClipboardApp.tsx
+++ b/src/ClipboardApp.tsx
@@ -260,7 +260,7 @@ function ClipboardApp() {
       case 'clipboard':
         if (isLoading) {
           return (
-            <div className="flex items-center justify-center h-full" tabIndex={-1}>
+            <div className="flex items-center justify-center h-full">
               <div className="w-6 h-6 border-2 border-win11-bg-accent border-t-transparent rounded-full animate-spin" />
             </div>
           )
@@ -276,12 +276,7 @@ function ClipboardApp() {
               onClearHistory={clearHistory}
               itemCount={history.filter((i) => !i.pinned).length}
             />
-            <div
-              className="flex flex-col gap-2 p-3"
-              role="listbox"
-              aria-label="Clipboard history"
-              tabIndex={-1}
-            >
+            <div className="flex flex-col gap-2 p-3" role="listbox" aria-label="Clipboard history">
               {history.map((item, index) => (
                 <HistoryItem
                   key={item.id}

--- a/src/components/DragHandle.tsx
+++ b/src/components/DragHandle.tsx
@@ -23,7 +23,6 @@ export function DragHandle() {
       data-tauri-drag-region
       className="relative w-full flex justify-center pt-4 pb-1 cursor-grab active:cursor-grabbing select-none"
       onMouseDown={handleMouseDown}
-      tabIndex={-1}
     >
       <div
         data-tauri-drag-region

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -197,7 +197,7 @@ export function EmojiPicker() {
 
   // Reset focus indices when emojis change
   useEffect(() => {
-    // eslint-disable-next-line
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setRecentFocusedIndex(0)
     setMainFocusedIndex(0)
   }, [searchQuery, selectedCategory])

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -8,7 +8,6 @@ export function EmptyState() {
     <div
       className="flex flex-col items-center justify-center h-full py-12 px-4 text-center"
       data-tauri-drag-region
-      tabIndex={-1}
     >
       <div className="w-16 h-16 rounded-full dark:bg-win11-bg-tertiary bg-win11Light-bg-tertiary flex items-center justify-center mb-4">
         <ClipboardList className="w-8 h-8 dark:text-win11-text-tertiary text-win11Light-text-secondary" />

--- a/src/components/GifPicker.tsx
+++ b/src/components/GifPicker.tsx
@@ -60,18 +60,12 @@ const GifCell = memo(function GifCell({
       >
         {/* Loading skeleton */}
         {!isLoaded && !hasError && (
-          <div
-            className="absolute inset-0 animate-pulse dark:bg-win11-bg-tertiary bg-win11Light-bg-tertiary"
-            tabIndex={-1}
-          />
+          <div className="absolute inset-0 animate-pulse dark:bg-win11-bg-tertiary bg-win11Light-bg-tertiary" />
         )}
 
         {/* Error state */}
         {hasError && (
-          <div
-            className="absolute inset-0 flex items-center justify-center text-xs dark:text-win11-text-disabled text-win11Light-text-disabled"
-            tabIndex={-1}
-          >
+          <div className="absolute inset-0 flex items-center justify-center text-xs dark:text-win11-text-disabled text-win11Light-text-disabled">
             Failed
           </div>
         )}

--- a/src/components/HistoryItem.tsx
+++ b/src/components/HistoryItem.tsx
@@ -172,10 +172,7 @@ export const HistoryItem = forwardRef<HTMLDivElement, HistoryItemProps>(function
 
       {/* Pinned badge */}
       {item.pinned && (
-        <div
-          className="absolute -top-1 -right-1 w-2 h-2 rounded-full bg-win11-bg-accent"
-          tabIndex={-1}
-        />
+        <div className="absolute -top-1 -right-1 w-2 h-2 rounded-full bg-win11-bg-accent" />
       )}
     </div>
   )


### PR DESCRIPTION
## 📝 Description
last ajustments to arrow navigation

## 🔗 Related Issue

Fixes #36 

## 🧪 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI change
- [x] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Chore (build process, dependencies, etc.)

## ✅ Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format`
- [x] I have tested my changes locally
- [x] I have added/updated documentation as needed
- [x] My changes don't introduce new warnings
- [x] I have tested on both X11 and Wayland (if applicable)

## 🖥️ Testing Environment

- **OS**: Ubuntu 
- **Desktop Environment**: Gnome 
- **Display Server**: X11

## Summary by Sourcery

Improve keyboard navigation and focus management across emoji picker, GIF picker, and clipboard history views for better accessibility and usability.

New Features:
- Add comprehensive arrow-key and paging navigation for emoji and GIF grids, including support for Home/End/PageUp/PageDown and selection via keyboard.
- Introduce roving tab index behavior for emoji categories, recent emojis, main emoji grid, GIF grid, and clipboard history items.

Enhancements:
- Refactor emoji and GIF grid rendering into dedicated cell components that carry focus state, ARIA attributes, and virtualized scrolling integration.
- Tighten focus handling by preventing non-interactive UI elements from receiving focus via tabIndex settings and improved role/ARIA usage.
- Update clipboard history keyboard behavior so arrow keys only act when a history item is focused and Tab returns focus to the tab bar.