### PR TITLE
feat: add cleanup function for previous AppImage installations

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -333,19 +333,12 @@ install_appimage() {
     # Wrapper script
     cat > "$HOME/.local/bin/win11-clipboard-history" << 'EOF'
 #!/bin/bash
-exec env -i \
-    HOME="$HOME" USER="$USER" SHELL="$SHELL" \
-    DISPLAY="${DISPLAY:-:0}" XAUTHORITY="$XAUTHORITY" \
-    WAYLAND_DISPLAY="$WAYLAND_DISPLAY" XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
-    XDG_SESSION_TYPE="$XDG_SESSION_TYPE" XDG_CURRENT_DESKTOP="$XDG_CURRENT_DESKTOP" \
-    XDG_DATA_DIRS="${XDG_DATA_DIRS:-/usr/local/share:/usr/share}" \
-    DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" \
-    PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin" \
-    LANG="${LANG:-en_US.UTF-8}" \
-    GDK_BACKEND="x11" \
-    GDK_SCALE="${GDK_SCALE:-1}" GDK_DPI_SCALE="${GDK_DPI_SCALE:-1}" \
-    NO_AT_BRIDGE=1 \
-    "$HOME/.local/bin/win11-clipboard-history.AppImage" "$@"
+export GDK_SCALE="${GDK_SCALE:-1}"
+export GDK_DPI_SCALE="${GDK_DPI_SCALE:-1}"
+export GDK_BACKEND="x11"
+export NO_AT_BRIDGE=1
+
+exec "$HOME/.local/bin/win11-clipboard-history.AppImage" "$@"
 EOF
     chmod +x "$HOME/.local/bin/win11-clipboard-history"
     


### PR DESCRIPTION
## 🔗 Related Issue

Fixes #53 

## 🧪 Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI change
- [x] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Chore (build process, dependencies, etc.)

## ✅ Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format`
- [x] I have tested my changes locally
- [x] I have added/updated documentation as needed
- [x] My changes don't introduce new warnings
- [x] I have tested on both X11 and Wayland (if applicable)

## 🖥️ Testing Environment

- **OS**: Ubuntu
- **Desktop Environment**: Gnome 
- **Display Server**: X11

## Summary by Sourcery

Ensure package manager installations cleanly replace any previous AppImage-based installations to avoid conflicts.

Bug Fixes:
- Remove residual AppImage binaries, desktop files, icons, and running processes that could conflict with package manager installations.

Enhancements:
- Add a pre-installation cleanup routine that detects and removes artifacts from older AppImage installs before running the package manager flow.