### PR TITLE
fix: resolve WebKit incompatibility on Pop!_OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ chmod +x ~/.local/bin/win11-clipboard-history.AppImage
 cat > ~/.local/bin/win11-clipboard-history << 'EOF'
 #!/bin/bash
 unset LD_LIBRARY_PATH LD_PRELOAD GTK_PATH GIO_MODULE_DIR
-export GDK_BACKEND="x11" NO_AT_BRIDGE=1
+export GDK_BACKEND="x11" NO_AT_BRIDGE=1 WEBKIT_DISABLE_COMPOSITING_MODE=1
 exec "$HOME/.local/bin/win11-clipboard-history.AppImage" "$@"
 EOF
 chmod +x ~/.local/bin/win11-clipboard-history

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -338,10 +338,12 @@ unset LD_LIBRARY_PATH
 unset LD_PRELOAD
 unset GTK_PATH
 unset GIO_MODULE_DIR
+unset WEBKIT_DISABLE_COMPOSITING_MODE
 
 export GDK_SCALE="${GDK_SCALE:-1}"
 export GDK_DPI_SCALE="${GDK_DPI_SCALE:-1}"
 export GDK_BACKEND="x11"
+export WEBKIT_DISABLE_COMPOSITING_MODE=1
 export NO_AT_BRIDGE=1
 
 exec "$HOME/.local/bin/win11-clipboard-history.AppImage" "$@"

--- a/src-tauri/bundle/linux/wrapper.sh
+++ b/src-tauri/bundle/linux/wrapper.sh
@@ -38,11 +38,13 @@ unset LD_LIBRARY_PATH
 unset LD_PRELOAD
 unset GTK_PATH
 unset GIO_MODULE_DIR
+unset WEBKIT_DISABLE_COMPOSITING_MODE
 
 export GDK_SCALE="${GDK_SCALE:-1}"
 export GDK_DPI_SCALE="${GDK_DPI_SCALE:-1}"
 
 export GDK_BACKEND="x11"
+export WEBKIT_DISABLE_COMPOSITING_MODE=1
 export TAURI_TRAY="${TAURI_TRAY:-libayatana-appindicator3}"
 
 # Disable AT-SPI to prevent accessibility bus warnings/delays


### PR DESCRIPTION
## 📝 Description
resolve WebKit incompatibility on Pop!_OS

## 🧪 Type of Change

<!-- Mark the appropriate option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Chore (build process, dependencies, etc.)

## 🖥️ Testing Environment

- **OS**: Pop!_OS
- **Desktop Environment**: COSMIC 
- **Display Server**: Wayland

## Summary by Sourcery

Ensure the Linux wrapper scripts and documented launch command set WebKit compositing mode compatibility flags for the AppImage, resolving WebKit issues on Pop!_OS and similar environments.

Documentation:
- Update README launch instructions to include the WebKit compositing compatibility environment variable.

Chores:
- Adjust Linux install and wrapper scripts to unset any preexisting WebKit compositing setting and explicitly disable WebKit compositing mode when launching the AppImage.