### PR TITLE
fix: debian dependencies had wrong package

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -72,7 +72,8 @@
           "xdotool",
           "wl-clipboard",
           "acl",
-          "policykit-1",
+          "polkitd",
+          "pkexec",
           "libwebkit2gtk-4.1-0 | libwebkit2gtk-4.0-37",
           "libgtk-3-0",
           "libayatana-appindicator3-1 | libappindicator3-1"
@@ -103,8 +104,6 @@
         "preRemoveScript": "bundle/linux/postrm.sh"
       }
     },
-    "resources": [
-      "bundle/linux/99-win11-clipboard-input.rules"
-    ]
+    "resources": ["bundle/linux/99-win11-clipboard-input.rules"]
   }
 }


### PR DESCRIPTION
## 📝 Description

Currently .deb package relies on meta package `policykit-1`, which was removed starting from ubuntu 25
You also wont find it on [debian packages](https://packages.debian.org/search?suite=stable&section=all&arch=any&searchon=names&keywords=policykit-1)

Which makes installation practically impossible on newer versions of debian-based systems

Replacing policykit-1 with proper polkit packages, suggested by apt, fixes installing

## 🧪 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧹 Chore (build process, dependencies, etc.)

## 📸 Screenshots (if applicable)

<img width="1080" height="466" alt="image" src="https://github.com/user-attachments/assets/7b7c28dd-741e-4b90-a75e-afe1631345f8" />
<img width="707" height="166" alt="image" src="https://github.com/user-attachments/assets/3f64482a-3719-48df-bd89-3da5bc614e91" />


## ✅ Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format`
- [x] I have tested my changes locally
- [x] My changes don't introduce new warnings

## 🖥️ Testing Environment

- **OS**:  Ubuntu 25

## Summary by Sourcery

Update Debian packaging configuration to replace the removed policykit-1 meta package with the appropriate polkit dependencies so the .deb installs correctly on newer Debian-based systems.

Bug Fixes:
- Fix .deb installation failures on recent Debian/Ubuntu versions by depending on available polkit packages instead of the deprecated policykit-1 meta package.

Build:
- Adjust Tauri packaging configuration for Debian targets to use the correct polkit-related packages in the generated .deb metadata.