### PR TITLE
fix: remove forced x11 backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ chmod +x ~/.local/bin/win11-clipboard-history.AppImage
 cat > ~/.local/bin/win11-clipboard-history << 'EOF'
 #!/bin/bash
 unset LD_LIBRARY_PATH LD_PRELOAD GTK_PATH GIO_MODULE_DIR
-export GDK_BACKEND="x11" NO_AT_BRIDGE=1
+export NO_AT_BRIDGE=1
 exec "$HOME/.local/bin/win11-clipboard-history.AppImage" "$@"
 EOF
 chmod +x ~/.local/bin/win11-clipboard-history

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -341,7 +341,6 @@ unset GIO_MODULE_DIR
 
 export GDK_SCALE="${GDK_SCALE:-1}"
 export GDK_DPI_SCALE="${GDK_DPI_SCALE:-1}"
-export GDK_BACKEND="x11"
 export NO_AT_BRIDGE=1
 
 exec "$HOME/.local/bin/win11-clipboard-history.AppImage" "$@"

--- a/src-tauri/bundle/linux/wrapper.sh
+++ b/src-tauri/bundle/linux/wrapper.sh
@@ -42,7 +42,6 @@ unset GIO_MODULE_DIR
 export GDK_SCALE="${GDK_SCALE:-1}"
 export GDK_DPI_SCALE="${GDK_DPI_SCALE:-1}"
 
-export GDK_BACKEND="x11"
 export TAURI_TRAY="${TAURI_TRAY:-libayatana-appindicator3}"
 
 # Disable AT-SPI to prevent accessibility bus warnings/delays

--- a/src-tauri/src/autostart_manager.rs
+++ b/src-tauri/src/autostart_manager.rs
@@ -1,7 +1,7 @@
 // Custom autostart manager for Linux that uses the wrapper script instead of the binary directly.
 // This is necessary because tauri-plugin-autostart uses current_exe() which points to the binary,
 // but we need to use the wrapper script that sets up the correct environment variables
-// (GDK_BACKEND, TAURI_TRAY, etc.) for proper tray icon functionality.
+// (TAURI_TRAY, etc.) for proper tray icon functionality.
 
 use std::fs;
 use std::io::Write;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Stop forcing the GDK X11 backend in wrapper and install scripts to improve compatibility with non-X11 environments.