### PR TITLE
fix: enhance focus and hover behavior in Emoji, Kaomoji, and Symbol pickers when keyboard is used

### DIFF
--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -43,7 +43,11 @@ const EmojiCell = memo(function EmojiCell({
       onClick={() => onSelect(emoji)}
       onMouseEnter={() => onHover?.(emoji)}
       onMouseLeave={() => onHover?.(null)}
-      onFocus={onItemFocus}
+      onFocus={() => {
+        onItemFocus?.()
+        onHover?.(emoji)
+      }}
+      onBlur={() => onHover?.(null)}
       onKeyDown={onKeyDown}
       tabIndex={tabIndex}
       data-main-index={mainIndex}

--- a/src/components/KaomojiPicker.tsx
+++ b/src/components/KaomojiPicker.tsx
@@ -126,10 +126,16 @@ export function KaomojiPicker({ isDark, opacity, customKaomojis = [] }: KaomojiP
               data-kaomoji-index={index}
               tabIndex={index === gridFocusedIndex ? 0 : -1}
               onClick={() => handlePaste(item.text)}
-              onFocus={() => setGridFocusedIndex(index)}
+              onFocus={() => {
+                setGridFocusedIndex(index)
+                setHoveredKaomoji({ text: item.text, category: item.category })
+              }}
+              onBlur={() => setHoveredKaomoji(null)}
               onKeyDown={(e) => handleGridKeyDown(e, index)}
               onMouseEnter={() => setHoveredKaomoji({ text: item.text, category: item.category })}
-              onMouseLeave={() => setHoveredKaomoji(null)}
+              onMouseLeave={() => {
+                setHoveredKaomoji(null)
+              }}
               className={clsx(
                 'h-12 flex items-center justify-center rounded-md text-sm',
                 'hover:scale-105 transition-transform duration-100 transform-gpu',

--- a/src/components/SymbolPicker.tsx
+++ b/src/components/SymbolPicker.tsx
@@ -43,7 +43,11 @@ const SymbolCell = memo(function SymbolCell({
       onClick={() => onSelect(symbol)}
       onMouseEnter={() => onHover?.(symbol)}
       onMouseLeave={() => onHover?.(null)}
-      onFocus={onItemFocus}
+      onFocus={() => {
+        onItemFocus?.()
+        onHover?.(symbol)
+      }}
+      onBlur={() => onHover?.(null)}
       onKeyDown={onKeyDown}
       tabIndex={tabIndex}
       data-main-index={mainIndex}


### PR DESCRIPTION
## 📝 Description
This PR fixes multiple focus/tooltip issues and stabilizes keyboard-driven behavior:
- Emoji and Symbol pickers: ensure the footer shows the correct emoji/symbol name when navigating with keyboard arrows

## 🔗 Related Issue

Fixes # https://github.com/gustavosett/Windows-11-Clipboard-History-For-Linux/issues/108

## 🧪 Type of Change

<!-- Mark the appropriate option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## 📸 Screenshots (if applicable)

<!-- Add screenshots to show UI changes -->

## ✅ Checklist

<!-- Mark completed items with an 'x' -->

- [ ] My code follows the project's code style
- [ ] I have run `make lint` and `make format`
- [x] I have tested my changes locally
- [ ] I have added/updated documentation as needed
- [ ] My changes don't introduce new warnings
- [ ] I have tested on both X11 and Wayland (if applicable)

## 🖥️ Testing Environment

- **OS**: Fedora 43
- **Desktop Environment**: GNOME
- **Display Server**: Wayland

## 📋 Additional Notes

## Summary by Sourcery

Improve keyboard-driven focus and hover behavior in emoji, kaomoji, and symbol pickers so footer/tooltip content stays in sync during navigation.

Bug Fixes:
- Ensure kaomoji hover state updates on keyboard focus and clears on blur to keep the footer information accurate.
- Trigger emoji hover updates on keyboard focus and clear them on blur to align keyboard navigation with mouse hover behavior.
- Trigger symbol hover updates on keyboard focus and clear them on blur so keyboard navigation correctly updates the displayed symbol details.

https://github.com/user-attachments/assets/f89c821a-d09b-471f-8495-a7f7d33cd265

