### PR TITLE
Feature/sync primary selection

### DIFF
--- a/src-tauri/src/clipboard_manager.rs
+++ b/src-tauri/src/clipboard_manager.rs
@@ -308,6 +308,18 @@ impl ClipboardManager {
         clipboard.get().html().ok()
     }
 
+    /// Get text from primary selection (Linux only).
+    /// Primary selection is the text highlighted with the mouse.
+    #[cfg(target_os = "linux")]
+    pub fn get_primary_selection_text(&self) -> Result<String, arboard::Error> {
+        use arboard::{GetExtLinux, LinuxClipboardKind};
+        let mut clipboard = Clipboard::new()?;
+        clipboard
+            .get()
+            .clipboard(LinuxClipboardKind::Primary)
+            .text()
+    }
+
     pub fn get_current_image(
         &mut self,
     ) -> Result<Option<(ImageData<'static>, u64)>, arboard::Error> {

--- a/src-tauri/src/clipboard_manager.rs
+++ b/src-tauri/src/clipboard_manager.rs
@@ -309,7 +309,7 @@ impl ClipboardManager {
     }
 
     /// Get text from the primary selection (text highlighted with mouse).
-    /// Works on X11 fully, and on Wayland with compositors supporting zwp_primary_selection v2+.
+    /// Works on X11 and Wayland (requires zwp_primary_selection protocol v2+).
     #[cfg(target_os = "linux")]
     pub fn get_primary_selection_text(&self) -> Result<String, arboard::Error> {
         use arboard::{GetExtLinux, LinuxClipboardKind};

--- a/src-tauri/src/clipboard_manager.rs
+++ b/src-tauri/src/clipboard_manager.rs
@@ -308,8 +308,8 @@ impl ClipboardManager {
         clipboard.get().html().ok()
     }
 
-    /// Get text from primary selection (Linux only).
-    /// Primary selection is the text highlighted with the mouse.
+    /// Get text from the primary selection (text highlighted with mouse).
+    /// Works on X11 fully, and on Wayland with compositors supporting zwp_primary_selection v2+.
     #[cfg(target_os = "linux")]
     pub fn get_primary_selection_text(&self) -> Result<String, arboard::Error> {
         use arboard::{GetExtLinux, LinuxClipboardKind};

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -639,7 +639,8 @@ fn start_clipboard_watcher(app: AppHandle, clipboard_manager: Arc<Mutex<Clipboar
         let mut cleanup_counter = 0;
 
         // Cache settings to avoid disk I/O on every 500ms iteration.
-        // Settings are reloaded every ~30 seconds (during cleanup check).
+        // Settings are loaded once at initialization and refreshed every ~30 seconds
+        // (during cleanup check) to pick up any user changes.
         let mut settings = UserSettingsManager::new().load();
 
         loop {
@@ -692,8 +693,8 @@ fn start_clipboard_watcher(app: AppHandle, clipboard_manager: Arc<Mutex<Clipboar
                 }
             }
 
-            // Primary Selection - sync highlighted text to clipboard history
-            // Works on X11 fully, Wayland requires zwp_primary_selection v2+
+            // Primary Selection - sync highlighted text to clipboard history.
+            // Works on X11 and Wayland (requires zwp_primary_selection protocol v2+).
             #[cfg(target_os = "linux")]
             if settings.sync_primary_selection {
                 if let Ok(primary_text) = manager.get_primary_selection_text() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -634,18 +634,21 @@ fn start_clipboard_watcher(app: AppHandle, clipboard_manager: Arc<Mutex<Clipboar
     std::thread::spawn(move || {
         let mut last_text_hash: Option<u64> = None;
         let mut last_image_hash: Option<u64> = None;
+        let mut last_primary_hash: Option<u64> = None;
         let mut cleanup_counter = 0;
 
         loop {
             std::thread::sleep(Duration::from_millis(500));
             cleanup_counter += 1;
 
+            // Load settings for this iteration (needed for cleanup interval and primary selection sync)
+            let settings = UserSettingsManager::new().load();
+
             let mut manager = clipboard_manager.lock();
 
             // Background cleanup every ~30 seconds (60 * 500ms)
             if cleanup_counter >= 60 {
                 cleanup_counter = 0;
-                let settings = UserSettingsManager::new().load();
                 let interval_in_minutes = settings.auto_delete_interval_in_minutes();
 
                 if interval_in_minutes > 0 && manager.cleanup_old_items(interval_in_minutes) {
@@ -654,7 +657,7 @@ fn start_clipboard_watcher(app: AppHandle, clipboard_manager: Arc<Mutex<Clipboar
                 }
             }
 
-            // Text
+            // Text (regular clipboard)
             if let Ok(text) = manager.get_current_text() {
                 if !text.is_empty() {
                     let text_hash =
@@ -681,6 +684,30 @@ fn start_clipboard_watcher(app: AppHandle, clipboard_manager: Arc<Mutex<Clipboar
                     last_text_hash = None;
                     if let Some(item) = manager.add_image(image_data, hash) {
                         let _ = app.emit("clipboard-changed", &item);
+                    }
+                }
+            }
+
+            // Primary Selection (Linux only) - sync highlighted text to clipboard history
+            #[cfg(target_os = "linux")]
+            if settings.sync_primary_selection {
+                if let Ok(primary_text) = manager.get_primary_selection_text() {
+                    if !primary_text.is_empty() {
+                        let primary_hash =
+                            win11_clipboard_history_lib::clipboard_manager::calculate_hash(
+                                &primary_text,
+                            );
+
+                        // Only add if different from last primary AND different from current clipboard
+                        if Some(primary_hash) != last_primary_hash
+                            && Some(primary_hash) != last_text_hash
+                        {
+                            last_primary_hash = Some(primary_hash);
+
+                            if let Some(item) = manager.add_text(primary_text, None) {
+                                let _ = app.emit("clipboard-changed", &item);
+                            }
+                        }
                     }
                 }
             }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -688,7 +688,8 @@ fn start_clipboard_watcher(app: AppHandle, clipboard_manager: Arc<Mutex<Clipboar
                 }
             }
 
-            // Primary Selection (Linux only) - sync highlighted text to clipboard history
+            // Primary Selection - sync highlighted text to clipboard history
+            // Works on X11 fully, Wayland requires zwp_primary_selection v2+
             #[cfg(target_os = "linux")]
             if settings.sync_primary_selection {
                 if let Ok(primary_text) = manager.get_primary_selection_text() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -634,21 +634,25 @@ fn start_clipboard_watcher(app: AppHandle, clipboard_manager: Arc<Mutex<Clipboar
     std::thread::spawn(move || {
         let mut last_text_hash: Option<u64> = None;
         let mut last_image_hash: Option<u64> = None;
+        #[cfg(target_os = "linux")]
         let mut last_primary_hash: Option<u64> = None;
         let mut cleanup_counter = 0;
+
+        // Cache settings to avoid disk I/O on every 500ms iteration.
+        // Settings are reloaded every ~30 seconds (during cleanup check).
+        let mut settings = UserSettingsManager::new().load();
 
         loop {
             std::thread::sleep(Duration::from_millis(500));
             cleanup_counter += 1;
 
-            // Load settings for this iteration (needed for cleanup interval and primary selection sync)
-            let settings = UserSettingsManager::new().load();
-
             let mut manager = clipboard_manager.lock();
 
             // Background cleanup every ~30 seconds (60 * 500ms)
+            // Also refresh cached settings on this interval
             if cleanup_counter >= 60 {
                 cleanup_counter = 0;
+                settings = UserSettingsManager::new().load();
                 let interval_in_minutes = settings.auto_delete_interval_in_minutes();
 
                 if interval_in_minutes > 0 && manager.cleanup_old_items(interval_in_minutes) {

--- a/src-tauri/src/user_settings.rs
+++ b/src-tauri/src/user_settings.rs
@@ -57,7 +57,8 @@ pub struct UserSettings {
     pub ui_scale: f32,
 
     // --- Primary Selection Sync ---
-    /// Sync primary selection (highlighted text) to clipboard history (Linux only)
+    /// Sync primary selection (highlighted text) to clipboard history.
+    /// Works on X11 fully, Wayland requires zwp_primary_selection v2+.
     #[serde(default)]
     pub sync_primary_selection: bool,
 }

--- a/src-tauri/src/user_settings.rs
+++ b/src-tauri/src/user_settings.rs
@@ -58,7 +58,7 @@ pub struct UserSettings {
 
     // --- Primary Selection Sync ---
     /// Sync primary selection (highlighted text) to clipboard history.
-    /// Works on X11 fully, Wayland requires zwp_primary_selection v2+.
+    /// Works on X11 and Wayland (requires zwp_primary_selection protocol v2+).
     #[serde(default)]
     pub sync_primary_selection: bool,
 }

--- a/src-tauri/src/user_settings.rs
+++ b/src-tauri/src/user_settings.rs
@@ -55,6 +55,11 @@ pub struct UserSettings {
     /// UI scale factor for the clipboard window (0.5 to 2.0, default 1.0)
     #[serde(default = "default_ui_scale")]
     pub ui_scale: f32,
+
+    // --- Primary Selection Sync ---
+    /// Sync primary selection (highlighted text) to clipboard history (Linux only)
+    #[serde(default)]
+    pub sync_primary_selection: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -99,6 +104,7 @@ impl Default for UserSettings {
             auto_delete_unit: "hours".to_string(),
             custom_kaomojis: Vec::new(),
             ui_scale: default_ui_scale(),
+            sync_primary_selection: false,
         }
     }
 }

--- a/src/ClipboardApp.tsx
+++ b/src/ClipboardApp.tsx
@@ -29,6 +29,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   auto_delete_unit: 'hours',
   custom_kaomojis: [],
   ui_scale: 1,
+  sync_primary_selection: false,
 }
 
 /**

--- a/src/SettingsApp.tsx
+++ b/src/SettingsApp.tsx
@@ -26,6 +26,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   ui_scale: 1,
   auto_delete_interval: 0,
   auto_delete_unit: 'hours',
+  sync_primary_selection: false,
 }
 
 type ThemeMode = 'system' | 'dark' | 'light'

--- a/src/components/FeaturesSection.tsx
+++ b/src/components/FeaturesSection.tsx
@@ -16,7 +16,7 @@ const FEATURES = [
   {
     key: 'sync_primary_selection',
     label: 'Sync Primary Selection',
-    desc: 'Copy highlighted text to clipboard history (Linux only).',
+    desc: 'Sync highlighted text to history (X11 fully, Wayland v2+).',
   },
 ] as const
 

--- a/src/components/FeaturesSection.tsx
+++ b/src/components/FeaturesSection.tsx
@@ -16,7 +16,7 @@ const FEATURES = [
   {
     key: 'sync_primary_selection',
     label: 'Sync Primary Selection',
-    desc: 'Sync highlighted text to history (X11 fully, Wayland v2+).',
+    desc: 'X11 and Wayland (requires zwp_primary_selection protocol v2+).',
   },
 ] as const
 

--- a/src/components/FeaturesSection.tsx
+++ b/src/components/FeaturesSection.tsx
@@ -13,6 +13,11 @@ const FEATURES = [
     label: 'UI Polish',
     desc: 'Enable animations and compact mode support.',
   },
+  {
+    key: 'sync_primary_selection',
+    label: 'Sync Primary Selection',
+    desc: 'Copy highlighted text to clipboard history (Linux only).',
+  },
 ] as const
 
 export function FeaturesSection({

--- a/src/types/clipboard.ts
+++ b/src/types/clipboard.ts
@@ -75,6 +75,7 @@ export interface UserSettings {
   auto_delete_unit: 'minutes' | 'hours' | 'days' | 'weeks'
   custom_kaomojis: CustomKaomoji[]
   ui_scale: number
+  sync_primary_selection: boolean
 }
 
 /** Helper type for boolean settings keys */


### PR DESCRIPTION
- Add sync_primary_selection setting to UserSettings (default: off)
- Add get_primary_selection_text() helper to ClipboardManager
- Modify clipboard watcher to monitor primary selection when enabled
- Add UI toggle in Settings > Features section
- Works on X11 and Wayland v2+ compositors

This feature allows Linux users to automatically capture highlighted text into clipboard history without pressing Ctrl+C.

## 📝 Description

Implements the "Sync Primary Selection" feature requested in #129. When enabled, the clipboard watcher polls the Linux primary selection (text highlighted with the mouse) and automatically adds it to clipboard history. Includes duplicate detection to avoid adding the same selection multiple times or duplicating content already in the regular clipboard.

**Files changed:**
- [user_settings.rs](cci:7://file:///home/sambit/projects/Windows-11-Clipboard-History-For-Linux/src-tauri/src/user_settings.rs:0:0-0:0) - Added `sync_primary_selection` boolean field
- [clipboard_manager.rs](cci:7://file:///home/sambit/projects/Windows-11-Clipboard-History-For-Linux/src-tauri/src/clipboard_manager.rs:0:0-0:0) - Added [get_primary_selection_text()](cci:1://file:///home/sambit/projects/Windows-11-Clipboard-History-For-Linux/src-tauri/src/clipboard_manager.rs:310:4-320:5) helper using arboard's `GetExtLinux` trait
- [main.rs](cci:7://file:///home/sambit/projects/Windows-11-Clipboard-History-For-Linux/src-tauri/src/main.rs:0:0-0:0) - Modified clipboard watcher loop to monitor primary selection when enabled
- [clipboard.ts](cci:7://file:///home/sambit/projects/Windows-11-Clipboard-History-For-Linux/src/types/clipboard.ts:0:0-0:0) - Added TypeScript type
- [SettingsApp.tsx](cci:7://file:///home/sambit/projects/Windows-11-Clipboard-History-For-Linux/src/SettingsApp.tsx:0:0-0:0) & [ClipboardApp.tsx](cci:7://file:///home/sambit/projects/Windows-11-Clipboard-History-For-Linux/src/ClipboardApp.tsx:0:0-0:0) - Added default setting
- [FeaturesSection.tsx](cci:7://file:///home/sambit/projects/Windows-11-Clipboard-History-For-Linux/src/components/FeaturesSection.tsx:0:0-0:0) - Added UI toggle

## 🔗 Related Issue

- #129

## 🧪 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Chore (build process, dependencies, etc.)

## 📸 Screenshots (if applicable)

N/A - The toggle appears in Settings > Features section using the existing toggle component pattern.

## ✅ Checklist

- [x] My code follows the project's code style
- [ ] I have run `make lint` and `make format`
- [x] I have tested my changes locally
- [x] I have added/updated documentation as needed
- [x] My changes don't introduce new warnings
- [x] I have tested on both X11 and Wayland (if applicable)

## 🖥️ Testing Environment

- **OS**: Ubuntu 24.04.3
- **Desktop Environment**: GNOME 46.0
- **Display Server**: Wayland

## 📋 Additional Notes

- Feature is opt-in (default: OFF)
- Only compiles on Linux using `#[cfg(target_os = "linux")]`
- Uses `arboard::LinuxClipboardKind::Primary` to access primary selection
- On Wayland, requires compositor supporting `zwp_primary_selection` protocol v2+
- Includes hash-based duplicate detection to avoid spamming history

## Summary by Sourcery

Add an opt-in feature to sync the Linux primary selection (highlighted text) into the clipboard history alongside the regular clipboard.

New Features:
- Introduce a sync_primary_selection user setting to control primary selection syncing on Linux.
- Add clipboard manager support for reading the primary selection using arboard on Linux.
- Expose a UI toggle in the Features settings section for enabling primary selection sync.