### PR TITLE
fix: sanitize GTK environment in install wrappers

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -333,7 +333,8 @@ install_appimage() {
     # Wrapper script
     cat > "$HOME/.local/bin/win11-clipboard-history" << 'EOF'
 #!/bin/bash
-# Clean up environment to avoid Snap/Flatpak library conflicts
+# Keep this function aligned with src-tauri/bundle/linux/wrapper.sh
+sanitize_runtime_env() {
 unset LD_LIBRARY_PATH
 unset LD_PRELOAD
 unset GTK_PATH
@@ -343,7 +344,25 @@ unset GTK_EXE_PREFIX
 unset LOCPATH
 unset GSETTINGS_SCHEMA_DIR
 
-export XDG_DATA_DIRS="/usr/local/share:/usr/share:/var/lib/snapd/desktop"
+local xdg_data_dirs="${XDG_DATA_DIRS:-}"
+local system_dirs=("/usr/local/share" "/usr/share" "/var/lib/snapd/desktop")
+
+if [ -z "$xdg_data_dirs" ]; then
+    xdg_data_dirs="${system_dirs[0]}:${system_dirs[1]}:${system_dirs[2]}"
+elif [[ "$xdg_data_dirs" == *"/snap/"* || "$xdg_data_dirs" == *"snap/code"* || -n "${SNAP:-}" ]]; then
+    local dir
+    for dir in "${system_dirs[@]}"; do
+        case ":$xdg_data_dirs:" in
+            *":$dir:"*) ;;
+            *) xdg_data_dirs="$xdg_data_dirs:$dir" ;;
+        esac
+    done
+fi
+
+export XDG_DATA_DIRS="$xdg_data_dirs"
+}
+
+sanitize_runtime_env
 
 export GDK_SCALE="${GDK_SCALE:-1}"
 export GDK_DPI_SCALE="${GDK_DPI_SCALE:-1}"

--- a/src-tauri/bundle/linux/wrapper.sh
+++ b/src-tauri/bundle/linux/wrapper.sh
@@ -33,18 +33,39 @@ if [ -z "$BINARY" ]; then
     exit 1
 fi
 
-# Clean up environment to avoid Snap/Flatpak library conflicts
-unset LD_LIBRARY_PATH
-unset LD_PRELOAD
-unset GTK_PATH
-unset GIO_MODULE_DIR
-unset GTK_IM_MODULE_FILE
-unset GTK_EXE_PREFIX
-unset LOCPATH
-unset GSETTINGS_SCHEMA_DIR
+sanitize_runtime_env() {
+    # Snap/Flatpak sandboxes may inject GTK/GIO/runtime paths from confined runtimes.
+    # Clear them so the app uses host system libraries consistently.
+    unset LD_LIBRARY_PATH
+    unset LD_PRELOAD
+    unset GTK_PATH
+    unset GIO_MODULE_DIR
+    unset GTK_IM_MODULE_FILE
+    unset GTK_EXE_PREFIX
+    unset LOCPATH
+    unset GSETTINGS_SCHEMA_DIR
 
-# Ensure system data dirs are preferred over snap-injected ones
-export XDG_DATA_DIRS="/usr/local/share:/usr/share:/var/lib/snapd/desktop"
+    # Keep user/system XDG_DATA_DIRS when valid.
+    # Only merge in defaults if empty or clearly snap-injected.
+    local xdg_data_dirs="${XDG_DATA_DIRS:-}"
+    local system_dirs=("/usr/local/share" "/usr/share" "/var/lib/snapd/desktop")
+
+    if [ -z "$xdg_data_dirs" ]; then
+        xdg_data_dirs="${system_dirs[0]}:${system_dirs[1]}:${system_dirs[2]}"
+    elif [[ "$xdg_data_dirs" == *"/snap/"* || "$xdg_data_dirs" == *"snap/code"* || -n "${SNAP:-}" ]]; then
+        local dir
+        for dir in "${system_dirs[@]}"; do
+            case ":$xdg_data_dirs:" in
+                *":$dir:"*) ;;
+                *) xdg_data_dirs="$xdg_data_dirs:$dir" ;;
+            esac
+        done
+    fi
+
+    export XDG_DATA_DIRS="$xdg_data_dirs"
+}
+
+sanitize_runtime_env
 
 export GDK_SCALE="${GDK_SCALE:-1}"
 export GDK_DPI_SCALE="${GDK_DPI_SCALE:-1}"


### PR DESCRIPTION
## 📝 Description
Fixes runtime startup issues in Snap-influenced environments by aligning installed launchers with the working dev cleanup behavior.

Changes:
- `src-tauri/bundle/linux/wrapper.sh`: unset additional GTK-related variables and force system `XDG_DATA_DIRS`.
- `scripts/install.sh` (AppImage wrapper generation): apply the same environment cleanup.

## 🔗 Related Issue
- #

## 🧪 Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Chore (build process, dependencies, etc.)

## 📸 Screenshots (if applicable)
N/A

## ✅ Checklist
- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format`
- [x] I have tested my changes locally
- [ ] I have added/updated documentation as needed
- [x] My changes don't introduce new warnings
- [ ] I have tested on both X11 and Wayland (if applicable)

## 🖥️ Testing Environment
- **OS**: Ubuntu 24 Linux
- **Desktop Environment**: GNOME
- **Display Server**: X11

## 📋 Additional Notes
Context observed locally:
- `make dev` worked reliably.
- installed launcher path could fail in Snap-injected env unless additional GTK-related vars were unset.

## Summary by Sourcery

Sanitize GTK-related environment variables in Linux launch wrappers to ensure consistent startup behavior in Snap-influenced environments.

Bug Fixes:
- Unset additional GTK and locale-related environment variables in the Linux bundle wrapper to avoid inheriting problematic desktop session state.
- Align the AppImage install wrapper’s environment cleanup with the development wrapper to prevent startup failures under Snap-injected environments.