### PR TITLE
feat: auto search while in clipboard

### DIFF
--- a/src/components/ClipboardTab.tsx
+++ b/src/components/ClipboardTab.tsx
@@ -114,7 +114,7 @@ export function ClipboardTab(props: {
       const activeElement = document.activeElement
 
       // Global shortcuts that should work regardless of focus
-      if (e.ctrlKey && e.key === 'f') {
+      if (e.ctrlKey && e.key.toLowerCase() === 'f') {
         e.preventDefault()
         setIsSearchVisible((prev) => {
           const newValue = !prev
@@ -128,7 +128,7 @@ export function ClipboardTab(props: {
       }
 
       // Close search with Escape - should work even when search input is focused
-      if (e.key === 'Escape' && isSearchVisible) {
+      if (e.key.toLowerCase() === 'escape' && isSearchVisible) {
         e.preventDefault()
         setIsSearchVisible(false)
         setSearchQuery('')


### PR DESCRIPTION
## 📝 Description

auto search without necessity of using ctrl + f

## 🔗 Related Issue

- #165

## Summary by Sourcery

Enable instant search activation in the clipboard tab when users start typing, in addition to the existing Ctrl+F shortcut.

New Features:
- Automatically show and update the clipboard search bar as users type printable characters outside input fields.

Enhancements:
- Refine keyboard handling in the clipboard tab to ignore modifier combinations and non-text keys when triggering search.