### PR TITLE
chore: remove slide animations from components

### DIFF
--- a/src/SettingsApp.tsx
+++ b/src/SettingsApp.tsx
@@ -326,7 +326,7 @@ function SettingsApp() {
           {(isSaving || saveMessage) && (
             <div
               className={clsx(
-                'flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium animate-in fade-in slide-in-from-right-4 duration-300',
+                'flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium duration-300',
                 saveMessage?.includes('Error')
                   ? 'bg-red-500/10 text-red-500'
                   : isDark

--- a/src/components/HistoryItem/index.tsx
+++ b/src/components/HistoryItem/index.tsx
@@ -120,8 +120,6 @@ export const HistoryItem = forwardRef<HTMLDivElement, HistoryItemProps>(function
         'group relative rounded-win11 cursor-pointer',
         effectiveCompact ? 'p-2' : 'p-3',
         'transition-all duration-150 ease-out',
-        // Animation delay based on index
-        'animate-in',
         // Blue ring has priority
         pinnedAndFocused,
         // Otherwise default focused ring

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -275,7 +275,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
 
   const steps = [
     // Step 0: Welcome
-    <div key="welcome" className="text-center animate-fade-in">
+    <div key="welcome" className="text-center">
       <div className="mb-6">
         <div
           className={clsx(
@@ -315,7 +315,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
     </div>,
 
     // Step 1: Permissions
-    <div key="permissions" className="animate-fade-in">
+    <div key="permissions">
       <div className="text-center mb-6">
         <div
           className={clsx(
@@ -379,7 +379,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
     </div>,
 
     // Step 2: Shortcut Configuration
-    <div key="shortcut" className="animate-fade-in">
+    <div key="shortcut">
       <div className="text-center mb-6">
         <div
           className={clsx(
@@ -558,7 +558,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
     </div>,
 
     // Step 3: Autostart
-    <div key="autostart" className="animate-fade-in">
+    <div key="autostart">
       <div className="text-center mb-6">
         <div
           className={clsx(
@@ -602,7 +602,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
     </div>,
 
     // Step 4: Done
-    <div key="done" className="text-center animate-fade-in">
+    <div key="done" className="text-center">
       <div className="mb-6">
         <div
           className={clsx(
@@ -674,7 +674,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
           : 'bg-win11Light-bg-primary text-win11Light-text-primary'
       )}
     >
-      <div className={clsx('w-full max-w-sm', 'animate-scale-in')}>
+      <div className="w-full max-w-sm">
         {steps[step]}
 
         {/* Progress dots */}

--- a/src/index.css
+++ b/src/index.css
@@ -152,24 +152,6 @@ body {
   }
 }
 
-/* Animations */
-@layer utilities {
-  .animate-in {
-    animation: fadeSlideIn 0.2s ease-out forwards;
-  }
-
-  @keyframes fadeSlideIn {
-    from {
-      opacity: 0;
-      transform: translateY(4px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-}
-
 /* Focus styles for accessibility */
 @layer components {
   .focus-ring {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -61,25 +61,6 @@ export default {
         'win11-card': '0 2px 8px rgba(0, 0, 0, 0.15)',
         'win11-elevated': '0 16px 48px rgba(0, 0, 0, 0.35)',
       },
-      animation: {
-        'fade-in': 'fadeIn 0.15s ease-out',
-        'slide-up': 'slideUp 0.2s ease-out',
-        'scale-in': 'scaleIn 0.15s ease-out',
-      },
-      keyframes: {
-        fadeIn: {
-          '0%': { opacity: '0' },
-          '100%': { opacity: '1' },
-        },
-        slideUp: {
-          '0%': { opacity: '0', transform: 'translateY(8px)' },
-          '100%': { opacity: '1', transform: 'translateY(0)' },
-        },
-        scaleIn: {
-          '0%': { opacity: '0', transform: 'scale(0.95)' },
-          '100%': { opacity: '1', transform: 'scale(1)' },
-        },
-      },
       fontFamily: {
         'segoe': ['"Segoe UI Variable"', '"Segoe UI"', 'system-ui', 'sans-serif'],
       },


### PR DESCRIPTION
## 📝 Description

remove slide animations from components

## Summary by Sourcery

Remove custom slide and fade animations from the UI components and styling configuration.

Enhancements:
- Remove Tailwind animation and keyframe configuration entries that are no longer used by components.
- Simplify setup wizard, settings app, and history item components by dropping animation-related utility classes from their markup.

Chores:
- Delete global CSS animation utilities and keyframes associated with slide/fade-in behaviors.