### PR TITLE
fix(clipboard): improve linux reliability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2077,6 +2078,7 @@
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2087,6 +2089,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2147,6 +2150,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -2371,6 +2375,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2509,6 +2514,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2763,6 +2769,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3820,6 +3827,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3877,6 +3885,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3886,6 +3895,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4105,6 +4115,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4144,6 +4155,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4230,6 +4242,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4323,6 +4336,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4382,6 +4396,7 @@
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2078,7 +2077,6 @@
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2089,7 +2087,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2150,7 +2147,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -2375,7 +2371,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2514,7 +2509,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2769,7 +2763,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3827,7 +3820,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3885,7 +3877,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3895,7 +3886,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4115,7 +4105,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4155,7 +4144,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4242,7 +4230,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4336,7 +4323,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4396,7 +4382,6 @@
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src-tauri/src/clipboard_manager.rs
+++ b/src-tauri/src/clipboard_manager.rs
@@ -710,17 +710,22 @@ impl ClipboardManager {
     /// Robustly set text to clipboard using xclip/wl-copy on Linux if available,
     /// falling back to arboard. This fixes issues on distros like Kali Linux.
     pub fn set_text_robust(&self, text: &str) -> Result<(), String> {
-        if crate::session::is_wayland() {
-            if let Ok(()) = self.set_clipboard_external("wl-copy", &["--type", "text/plain"], text) {
-                return Ok(());
-            }
-        } else {
-            if let Ok(()) = self.set_clipboard_external(
-                "xclip",
-                &["-selection", "clipboard", "-t", "text/plain"],
-                text,
-            ) {
-                return Ok(());
+        #[cfg(target_os = "linux")]
+        {
+            if crate::session::is_wayland() {
+                if let Ok(()) =
+                    self.set_clipboard_external("wl-copy", &["--type", "text/plain"], text)
+                {
+                    return Ok(());
+                }
+            } else {
+                if let Ok(()) = self.set_clipboard_external(
+                    "xclip",
+                    &["-selection", "clipboard", "-t", "text/plain"],
+                    text,
+                ) {
+                    return Ok(());
+                }
             }
         }
 
@@ -732,23 +737,28 @@ impl ClipboardManager {
     /// Robustly set HTML to clipboard using xclip/wl-copy on Linux if available,
     /// falling back to arboard.
     pub fn set_html_robust(&self, html: &str, plain: &str) -> Result<(), String> {
-        if crate::session::is_wayland() {
-            // wl-copy doesn't easily support multiple types in one go for text/html + text/plain
-            // efficiently without multiple processes, so we prioritize HTML.
-            if let Ok(()) = self.set_clipboard_external("wl-copy", &["--type", "text/html"], html) {
-                return Ok(());
-            }
-        } else {
-            if let Ok(()) = self.set_clipboard_external(
-                "xclip",
-                &["-selection", "clipboard", "-t", "text/html"],
-                html,
-            ) {
-                return Ok(());
+        #[cfg(target_os = "linux")]
+        {
+            if crate::session::is_wayland() {
+                // wl-copy doesn't easily support multiple types in one go for text/html + text/plain
+                // efficiently without multiple processes, so we prioritize HTML then Plain.
+                let _ = self.set_clipboard_external("wl-copy", &["--type", "text/html"], html);
+                let _ = self.set_clipboard_external("wl-copy", &["--type", "text/plain"], plain);
+            } else {
+                let _ = self.set_clipboard_external(
+                    "xclip",
+                    &["-selection", "clipboard", "-t", "text/html"],
+                    html,
+                );
+                let _ = self.set_clipboard_external(
+                    "xclip",
+                    &["-selection", "clipboard", "-t", "text/plain"],
+                    plain,
+                );
             }
         }
 
-        // Fallback to arboard
+        // Fallback to arboard (which handles multiple MIME types correctly)
         let mut clipboard = get_system_clipboard()?;
         clipboard
             .set_html(html, Some(plain))
@@ -756,8 +766,8 @@ impl ClipboardManager {
     }
 
     fn set_clipboard_external(&self, cmd: &str, args: &[&str], data: &str) -> Result<(), String> {
+        use std::io::{Read, Write};
         use std::process::{Command, Stdio};
-        use std::io::Write;
 
         let mut child = Command::new(cmd)
             .args(args)
@@ -778,7 +788,16 @@ impl ClipboardManager {
 
         match child.try_wait() {
             Ok(Some(status)) if !status.success() => {
-                Err(format!("{} exited with error", cmd))
+                let mut stderr = String::new();
+                if let Some(mut stderr_pipe) = child.stderr.take() {
+                    let _ = stderr_pipe.read_to_string(&mut stderr);
+                }
+                Err(format!(
+                    "{} exited with status {}. Stderr: {}",
+                    cmd,
+                    status,
+                    stderr.trim()
+                ))
             }
             Ok(_) => {
                 // If it's still running or exited successfully, we assume it worked.

--- a/src-tauri/src/clipboard_manager.rs
+++ b/src-tauri/src/clipboard_manager.rs
@@ -713,15 +713,17 @@ impl ClipboardManager {
         #[cfg(target_os = "linux")]
         {
             if crate::session::is_wayland() {
-                if let Ok(()) =
-                    self.set_clipboard_external("wl-copy", &["--type", "text/plain"], text)
-                {
+                if let Ok(()) = self.set_clipboard_external(
+                    "wl-copy",
+                    &["--type", "text/plain;charset=utf-8"],
+                    text,
+                ) {
                     return Ok(());
                 }
             } else {
                 if let Ok(()) = self.set_clipboard_external(
                     "xclip",
-                    &["-selection", "clipboard", "-t", "text/plain"],
+                    &["-selection", "clipboard", "-t", "UTF8_STRING"],
                     text,
                 ) {
                     return Ok(());

--- a/src-tauri/src/clipboard_manager.rs
+++ b/src-tauri/src/clipboard_manager.rs
@@ -20,6 +20,7 @@ pub const DEFAULT_MAX_HISTORY_SIZE: usize = 50;
 const PREVIEW_TEXT_MAX_LEN: usize = 100;
 const GIF_CACHE_MARKER: &str = "win11-clipboard-history/gifs/";
 const FILE_URI_PREFIX: &str = "file://";
+const WL_COPY_SETTLE_TIME: u64 = 150;
 
 // --- Helper Functions ---
 
@@ -618,7 +619,7 @@ impl ClipboardManager {
                 self.last_pasted_text = Some(text.clone());
                 self.last_pasted_image_hash = None;
             }
-            ClipboardContent::RichText { plain, .. } => {
+            ClipboardContent::RichText { plain, html } => {
                 self.last_pasted_text = Some(plain.clone());
                 self.last_pasted_image_hash = None;
             }
@@ -647,19 +648,18 @@ impl ClipboardManager {
 
         match &item.content {
             ClipboardContent::Text(text) => {
-                clipboard.set_text(text).map_err(|e| e.to_string())?;
+                self.set_text_robust(text)?;
             }
             ClipboardContent::RichText { plain, html } => {
                 // Set HTML with plain text as fallback - this preserves formatting
-                clipboard
-                    .set_html(html, Some(plain))
-                    .map_err(|e| e.to_string())?;
+                self.set_html_robust(html, plain)?;
             }
             ClipboardContent::Image {
                 base64,
                 width,
                 height,
             } => {
+                let mut clipboard = get_system_clipboard()?;
                 self.write_image_to_clipboard(&mut clipboard, base64, *width, *height)?;
             }
         }
@@ -707,5 +707,92 @@ impl ClipboardManager {
         thread::sleep(Duration::from_millis(250));
 
         Ok(())
+    }
+
+    /// Robustly set text to clipboard using xclip/wl-copy on Linux if available,
+    /// falling back to arboard. This fixes issues on distros like Kali Linux.
+    pub fn set_text_robust(&self, text: &str) -> Result<(), String> {
+        if crate::session::is_wayland() {
+            if let Ok(()) = self.set_clipboard_external("wl-copy", &["--type", "text/plain"], text) {
+                return Ok(());
+            }
+        } else {
+            if let Ok(()) = self.set_clipboard_external(
+                "xclip",
+                &["-selection", "clipboard", "-t", "text/plain"],
+                text,
+            ) {
+                return Ok(());
+            }
+        }
+
+        // Fallback to arboard
+        let mut clipboard = get_system_clipboard()?;
+        clipboard.set_text(text).map_err(|e| e.to_string())
+    }
+
+    /// Robustly set HTML to clipboard using xclip/wl-copy on Linux if available,
+    /// falling back to arboard.
+    pub fn set_html_robust(&self, html: &str, plain: &str) -> Result<(), String> {
+        if crate::session::is_wayland() {
+            // wl-copy doesn't easily support multiple types in one go for text/html + text/plain
+            // efficiently without multiple processes, so we prioritize HTML.
+            if let Ok(()) = self.set_clipboard_external("wl-copy", &["--type", "text/html"], html) {
+                return Ok(());
+            }
+        } else {
+            if let Ok(()) = self.set_clipboard_external(
+                "xclip",
+                &["-selection", "clipboard", "-t", "text/html"],
+                html,
+            ) {
+                return Ok(());
+            }
+        }
+
+        // Fallback to arboard
+        let mut clipboard = get_system_clipboard()?;
+        clipboard
+            .set_html(html, Some(plain))
+            .map_err(|e| e.to_string())
+    }
+
+    fn set_clipboard_external(&self, cmd: &str, args: &[&str], data: &str) -> Result<(), String> {
+        use std::process::{Command, Stdio};
+        use std::io::Write;
+
+        let mut child = Command::new(cmd)
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("Failed to spawn {}: {}", cmd, e))?;
+
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin
+                .write_all(data.as_bytes())
+                .map_err(|e| format!("Pipe write error: {}", e))?;
+        }
+
+        // Wait briefly to see if it crashed
+        thread::sleep(Duration::from_millis(WL_COPY_SETTLE_TIME));
+
+        match child.try_wait() {
+            Ok(Some(status)) if !status.success() => {
+                Err(format!("{} exited with error", cmd))
+            }
+            Ok(_) => {
+                // If it's still running or exited successfully, we assume it worked.
+                // For xclip/wl-copy, they often background themselves or stay alive to serve content.
+                if cmd == "xclip" {
+                    thread::spawn(move || {
+                        let _ = child.wait();
+                    });
+                }
+                Ok(())
+            }
+            Err(e) => Err(format!("Process status check failed: {}", e)),
+        }
     }
 }

--- a/src-tauri/src/clipboard_manager.rs
+++ b/src-tauri/src/clipboard_manager.rs
@@ -619,7 +619,7 @@ impl ClipboardManager {
                 self.last_pasted_text = Some(text.clone());
                 self.last_pasted_image_hash = None;
             }
-            ClipboardContent::RichText { plain, html } => {
+            ClipboardContent::RichText { plain, html: _ } => {
                 self.last_pasted_text = Some(plain.clone());
                 self.last_pasted_image_hash = None;
             }
@@ -644,8 +644,6 @@ impl ClipboardManager {
         self.mark_as_pasted(item);
 
         // 2. Write content to OS clipboard
-        let mut clipboard = get_system_clipboard()?;
-
         match &item.content {
             ClipboardContent::Text(text) => {
                 self.set_text_robust(text)?;

--- a/src-tauri/src/clipboard_manager.rs
+++ b/src-tauri/src/clipboard_manager.rs
@@ -740,21 +740,21 @@ impl ClipboardManager {
         #[cfg(target_os = "linux")]
         {
             if crate::session::is_wayland() {
-                // wl-copy doesn't easily support multiple types in one go for text/html + text/plain
-                // efficiently without multiple processes, so we prioritize HTML then Plain.
-                let _ = self.set_clipboard_external("wl-copy", &["--type", "text/html"], html);
-                let _ = self.set_clipboard_external("wl-copy", &["--type", "text/plain"], plain);
+                if let Ok(()) =
+                    self.set_clipboard_external("wl-copy", &["--type", "text/html"], html)
+                {
+                    let _ = self.set_text_robust(plain);
+                    return Ok(());
+                }
             } else {
-                let _ = self.set_clipboard_external(
+                if let Ok(()) = self.set_clipboard_external(
                     "xclip",
                     &["-selection", "clipboard", "-t", "text/html"],
                     html,
-                );
-                let _ = self.set_clipboard_external(
-                    "xclip",
-                    &["-selection", "clipboard", "-t", "text/plain"],
-                    plain,
-                );
+                ) {
+                    let _ = self.set_text_robust(plain);
+                    return Ok(());
+                }
             }
         }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -206,12 +206,7 @@ async fn paste_text(
     {
         let mut manager = state.clipboard_manager.lock();
         manager.mark_text_as_pasted(&text);
-
-        use arboard::Clipboard;
-        Clipboard::new()
-            .map_err(|e| e.to_string())?
-            .set_text(&text)
-            .map_err(|e| e.to_string())?;
+        manager.set_text_robust(&text)?;
     }
 
     // 3. Simulate Paste


### PR DESCRIPTION
- Implemented robust text and HTML setting using `xclip` and `wl-copy`
- Added fallback to `arboard` for better compatibility on Linux distros (especially Kali Linux)
- Fixed Rust compiler warnings regarding unused variables and mutability
- Updated `package-lock.json` with dependency metadata from local build attempts

## 📝 Description

This PR addresses an issue where text-based items (Emojis, Kaomojis, Icons) failed to paste on certain Linux distributions like Kali Linux. 

Previously, text pasting relied solely on the `arboard` crate, which sometimes fails to own the clipboard correctly on specific X11/Wayland configurations. By adopting a robust approach similar to how GIFs are handled—using standard system tools (`xclip` and `wl-copy`) as primary setters—the reliability of pasting has been significantly improved.

Key changes:
- Added `set_text_robust` and `set_html_robust` helper methods in `ClipboardManager`.
- Updated `paste_item` and the `paste_text` command to use these robust setters.

## 🔗 Related Issue



## 🧪 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI change
- [x] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Chore (build process, dependencies, etc.)

## 📸 Screenshots (if applicable)

Nope

## ✅ Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format`
- [x] I have tested my changes locally
- [ ] I have added/updated documentation as needed
- [x] My changes don't introduce new warnings
- [x] I have tested on X11

## 🖥️ Testing Environment

- **OS**: Kali Linux
- **Desktop Environment**: XFCE
- **Display Server**: X11

## 📋 Additional Notes

The use of `xclip` and `wl-copy` ensures that the clipboard content is broadcasted using standard protocols that most Linux applications expect, providing a much higher success rate for "Paste on Click" functionality.

## Summary by Sourcery

Improve Linux clipboard reliability by using external clipboard tools with robust fallbacks for text and HTML pasting.

New Features:
- Add robust clipboard setters for text and HTML that prefer wl-copy/xclip on Linux with fallback to the existing clipboard backend.

Bug Fixes:
- Fix failures to paste text-based clipboard items on certain Linux distributions by changing how clipboard ownership is established.

Enhancements:
- Update clipboard paste flows to reuse the new robust setters and clean up unused variables and mutability warnings in clipboard handling code.

Build:
- Refresh package-lock.json dependency metadata from local builds.