### PR TITLE
Fix/audit bugs

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for the main and settings windows",
-  "windows": ["main", "settings"],
+  "description": "Capability for the main, setup and settings windows",
+  "windows": ["main", "setup", "settings"],
   "permissions": [
     "core:default",
     "core:window:default",

--- a/src-tauri/src/clipboard_manager.rs
+++ b/src-tauri/src/clipboard_manager.rs
@@ -402,11 +402,12 @@ impl ClipboardManager {
 
         // Skip self-pasted content
         if let Some(ref pasted) = self.last_pasted_text {
-            if pasted == text || text.contains(pasted) {
-                // Clear the lock so future copies allow this text
+            if pasted == text {
                 self.last_pasted_text = None;
                 return true;
             }
+            // Clipboard has changed to something else; the paste echo window has passed.
+            self.last_pasted_text = None;
         }
 
         false

--- a/src-tauri/src/user_settings.rs
+++ b/src-tauri/src/user_settings.rs
@@ -13,10 +13,8 @@ pub struct UserSettings {
     /// Theme mode: "system", "dark", or "light"
     pub theme_mode: String,
     /// Background opacity for dark mode (0.0 to 1.0)
-    /// Default matches the original glass-effect alpha of 0.05
     pub dark_background_opacity: f32,
     /// Background opacity for light mode (0.0 to 1.0)
-    /// Default matches the original glass-effect-light alpha of 0.85
     pub light_background_opacity: f32,
 
     // --- Feature Flags ---
@@ -233,8 +231,8 @@ mod tests {
     fn test_default_settings() {
         let settings = UserSettings::default();
         assert_eq!(settings.theme_mode, "system");
-        assert!((settings.dark_background_opacity - 0.05).abs() < f32::EPSILON);
-        assert!((settings.light_background_opacity - 0.85).abs() < f32::EPSILON);
+        assert!((settings.dark_background_opacity - 0.70).abs() < f32::EPSILON);
+        assert!((settings.light_background_opacity - 0.70).abs() < f32::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
Three small fixes found while auditing the codebase. Each is independent and self-contained.

## fix(setup): grant default capability to the setup window

The first-run setup wizard runs in a window labeled `setup`. `src-tauri/capabilities/default.json` listed only `main` and `settings`. Per the Tauri 2 capability model, a window not matched by any capability has no IPC access at all, so every `invoke()` from `SetupWizard.tsx` and `setup.tsx` (`check_permissions`, `check_shortcut_tools`, `detect_conflicts`, `resolve_conflicts`, `fix_permissions_now`, `register_de_shortcut`, `mark_first_run_complete`, `finish_setup`) fails on a fresh install. Fix: add `setup` to the `windows` array.

## fix(clipboard): only skip exact self-paste echoes

`should_skip_text` matched both `pasted == text` *and* `text.contains(pasted)`. The contains branch was added in e763ac6 to absorb GIF-paste echoes, but that case is now handled unconditionally by the earlier `FILE_URI_PREFIX && GIF_CACHE_MARKER` early-out. The only remaining effect of the contains branch is a false positive: after pasting `foo`, the next copy of any string containing `foo` (e.g. `foobar`) is silently dropped from history and the self-paste lock is cleared. Equality is sufficient.

## fix(test): update default-opacity assertions to match defaults

`test_default_settings` asserted `dark_background_opacity ≈ 0.05` and `light_background_opacity ≈ 0.85`, but `UserSettings::default()` sets both to `0.70`. CI runs `cargo fmt`, `cargo clippy` and `tauri build`, never `cargo test`, so the broken assertions were never exercised.

## Summary by Sourcery

Align setup, clipboard, and default settings behavior with intended semantics discovered during a code audit.

Bug Fixes:
- Grant the setup window the default capability so first-run IPC calls succeed on fresh installs.
- Adjust clipboard self-paste suppression to only skip exact echoes and avoid dropping subsequent related copies from history.
- Correct default background opacity tests to match the current UserSettings defaults.

Tests:
- Update opacity-related unit tests to assert the actual default values used in production settings.