### PR TITLE
Feat/pinned section

### DIFF
--- a/src/components/ClipboardTab.tsx
+++ b/src/components/ClipboardTab.tsx
@@ -49,7 +49,9 @@ export function ClipboardTab(props: {
   })
 
   useEffect(() => {
-    localStorage.setItem('clipboard-history-compact-mode', String(isCompact))
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('clipboard-history-compact-mode', String(isCompact))
+    }
   }, [isCompact])
   const [isSearchVisible, setIsSearchVisible] = useState(false)
   const searchInputRef = useRef<HTMLInputElement>(null)
@@ -69,7 +71,9 @@ export function ClipboardTab(props: {
   })
 
   useEffect(() => {
-    localStorage.setItem('clipboard-pinned-expanded', String(pinnedExpanded))
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('clipboard-pinned-expanded', String(pinnedExpanded))
+    }
   }, [pinnedExpanded])
 
   // Check if a key is a printable character that should trigger search
@@ -340,66 +344,89 @@ export function ClipboardTab(props: {
         </div>
       ) : (
         <div className="flex flex-col gap-2 p-3" role="listbox" aria-label="Clipboard history">
-          {showSections && (
-            <button
-              onClick={() => {
-                const willCollapse = pinnedExpanded
-                setPinnedExpanded(!pinnedExpanded)
-                if (willCollapse) {
-                  setFocusedIndex(0)
-                  setTimeout(() => historyItemRefs.current[0]?.focus(), 0)
-                }
-              }}
-              className={clsx(
-                'flex items-center gap-1.5 px-1 py-1 text-xs font-medium',
-                'dark:text-win11-text-tertiary text-win11Light-text-tertiary',
-                'hover:dark:text-win11-text-secondary hover:text-win11Light-text-secondary',
-                'rounded transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-win11-bg-accent'
-              )}
-              aria-expanded={pinnedExpanded}
-            >
-              <Pin size={12} />
-              <span>Pinned</span>
-              <span className="ml-auto opacity-60">{pinnedItems.length}</span>
-              <ChevronDown
-                size={12}
+          {showSections ? (
+            <>
+              <button
+                onClick={() => {
+                  const willCollapse = pinnedExpanded
+                  setPinnedExpanded(!pinnedExpanded)
+                  if (willCollapse) {
+                    setFocusedIndex(0)
+                    setTimeout(() => historyItemRefs.current[0]?.focus(), 0)
+                  }
+                }}
                 className={clsx(
-                  'transition-transform duration-150',
-                  !pinnedExpanded && '-rotate-90'
+                  'flex items-center gap-1.5 px-1 py-1 text-xs font-medium',
+                  'dark:text-win11-text-tertiary text-win11Light-text-tertiary',
+                  'hover:dark:text-win11-text-secondary hover:text-win11Light-text-secondary',
+                  'rounded transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-win11-bg-accent'
                 )}
-              />
-            </button>
-          )}
-          {pinnedExpanded && pinnedItems.map((item, offset) => (
-            <HistoryItem
-              key={item.id}
-              ref={(el) => {
-                historyItemRefs.current[offset] = el
-              }}
-              item={item}
-              index={offset}
-              isFocused={offset === focusedIndex}
-              onPaste={onPaste}
-              onDelete={deleteItem}
-              onTogglePin={togglePin}
-              onFocus={() => setFocusedIndex(offset)}
-              isDark={isDark}
-              secondaryOpacity={secondaryOpacity}
-              isCompact={isCompact}
-              enableSmartActions={settings.enable_smart_actions}
-              enableUiPolish={settings.enable_ui_polish}
-            />
-          ))}
-          {showSections && unpinnedItems.length > 0 && (
-            <div className="flex items-center gap-1.5 px-1 py-1 text-xs dark:text-win11-text-tertiary text-win11Light-text-tertiary">
-              <History size={12} />
-              <span>Recent</span>
-              <span className="ml-auto opacity-60">{unpinnedItems.length}</span>
-            </div>
-          )}
-          {unpinnedItems.map((item, offset) => {
-            const idx = showSections && pinnedExpanded ? pinnedItems.length + offset : offset
-            return (
+                aria-expanded={pinnedExpanded}
+              >
+                <Pin size={12} />
+                <span>Pinned</span>
+                <span className="ml-auto opacity-60">{pinnedItems.length}</span>
+                <ChevronDown
+                  size={12}
+                  className={clsx(
+                    'transition-transform duration-150',
+                    !pinnedExpanded && '-rotate-90'
+                  )}
+                />
+              </button>
+              {pinnedExpanded && pinnedItems.map((item, offset) => (
+                <HistoryItem
+                  key={item.id}
+                  ref={(el) => {
+                    historyItemRefs.current[offset] = el
+                  }}
+                  item={item}
+                  index={offset}
+                  isFocused={offset === focusedIndex}
+                  onPaste={onPaste}
+                  onDelete={deleteItem}
+                  onTogglePin={togglePin}
+                  onFocus={() => setFocusedIndex(offset)}
+                  isDark={isDark}
+                  secondaryOpacity={secondaryOpacity}
+                  isCompact={isCompact}
+                  enableSmartActions={settings.enable_smart_actions}
+                  enableUiPolish={settings.enable_ui_polish}
+                />
+              ))}
+              {unpinnedItems.length > 0 && (
+                <div className="flex items-center gap-1.5 px-1 py-1 text-xs dark:text-win11-text-tertiary text-win11Light-text-tertiary">
+                  <History size={12} />
+                  <span>Recent</span>
+                  <span className="ml-auto opacity-60">{unpinnedItems.length}</span>
+                </div>
+              )}
+              {unpinnedItems.map((item, offset) => {
+                const idx = pinnedItems.length + offset
+                return (
+                  <HistoryItem
+                    key={item.id}
+                    ref={(el) => {
+                      historyItemRefs.current[idx] = el
+                    }}
+                    item={item}
+                    index={idx}
+                    isFocused={idx === focusedIndex}
+                    onPaste={onPaste}
+                    onDelete={deleteItem}
+                    onTogglePin={togglePin}
+                    onFocus={() => setFocusedIndex(idx)}
+                    isDark={isDark}
+                    secondaryOpacity={secondaryOpacity}
+                    isCompact={isCompact}
+                    enableSmartActions={settings.enable_smart_actions}
+                    enableUiPolish={settings.enable_ui_polish}
+                  />
+                )
+              })}
+            </>
+          ) : (
+            filteredHistory.map((item, idx) => (
               <HistoryItem
                 key={item.id}
                 ref={(el) => {
@@ -418,8 +445,8 @@ export function ClipboardTab(props: {
                 enableSmartActions={settings.enable_smart_actions}
                 enableUiPolish={settings.enable_ui_polish}
               />
-            )
-          })}
+            ))
+          )}
         </div>
       )}
     </>

--- a/src/components/ClipboardTab.tsx
+++ b/src/components/ClipboardTab.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useRef, useEffect, useCallback } from 'react'
 import { listen } from '@tauri-apps/api/event'
 import { clsx } from 'clsx'
+import { Pin, History, ChevronDown } from 'lucide-react'
 
 import type { ClipboardItem, UserSettings } from '../types/clipboard'
 import type { TabBarRef } from './TabBar'
@@ -58,6 +59,19 @@ export function ClipboardTab(props: {
   // Refs
   const historyItemRefs = useRef<(HTMLDivElement | null)[]>([])
 
+  // Pinned section collapsible state (persisted)
+  const [pinnedExpanded, setPinnedExpanded] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('clipboard-pinned-expanded')
+      return stored !== null ? stored === 'true' : true
+    }
+    return true
+  })
+
+  useEffect(() => {
+    localStorage.setItem('clipboard-pinned-expanded', String(pinnedExpanded))
+  }, [pinnedExpanded])
+
   // Check if a key is a printable character that should trigger search
   const isPrintableKey = useCallback((e: KeyboardEvent): boolean => {
     // Skip if any modifier key is pressed (except Shift for uppercase/symbols)
@@ -104,7 +118,6 @@ export function ClipboardTab(props: {
     ]
     if (specialKeys.includes(e.key)) return false
 
-    // Accept single printable characters (letters, numbers, symbols)
     return e.key.length === 1
   }, [])
 
@@ -135,29 +148,25 @@ export function ClipboardTab(props: {
         return
       }
 
-      // Skip instant filtering if focus is on an input element (user is already typing in search)
+      // Skip if focus is on an input or tab (those have their own handlers)
       if (activeElement?.tagName === 'INPUT' || activeElement?.tagName === 'TEXTAREA') return
-
-      // Skip if focus is on a tab button (let tab navigation handle it)
       if (activeElement?.getAttribute('role') === 'tab') return
 
       // Instant filtering: start typing to activate search
       if (isPrintableKey(e)) {
         e.preventDefault()
-        // Show search bar and append the typed character
         if (!isSearchVisible) {
           setIsSearchVisible(true)
           setSearchQuery(e.key)
         } else {
           setSearchQuery((prev) => prev + e.key)
         }
-        // Focus will be set by the useEffect that watches isSearchVisible
       }
     },
     [isSearchVisible, isPrintableKey]
   )
 
-  // Listen for Ctrl+F
+  // Listen for Ctrl+F keybinding
   useEffect(() => {
     globalThis.addEventListener('keydown', handleKeyDown)
     return () => globalThis.removeEventListener('keydown', handleKeyDown)
@@ -170,7 +179,7 @@ export function ClipboardTab(props: {
     }
   }, [isSearchVisible])
 
-  // Reset search when window is shown (app reopened)
+  // Reset search when window is shown (reopened)
   useEffect(() => {
     const resetSearch = () => {
       setIsSearchVisible(false)
@@ -182,7 +191,7 @@ export function ClipboardTab(props: {
     }
   }, [])
 
-  // Filter history
+  // Filter history by search query
   const filteredHistory = useMemo(() => {
     if (!searchQuery) return history
 
@@ -215,14 +224,45 @@ export function ClipboardTab(props: {
     })
   }, [history, searchQuery, isRegexMode])
 
+  // Split into pinned / unpinned sections
+  const pinnedItems = useMemo(() => filteredHistory.filter((i) => i.pinned), [filteredHistory])
+  const unpinnedItems = useMemo(() => filteredHistory.filter((i) => !i.pinned), [filteredHistory])
+
+  const showSections = !searchQuery && pinnedItems.length > 0
+
+  // Flat item array for keyboard navigation
+  const visibleItems = showSections && !pinnedExpanded ? unpinnedItems : filteredHistory
+
+  // Keyboard navigation callbacks for section collapse/expand
+  const onUpFromFirstItem = useCallback(() => {
+    if (showSections && !pinnedExpanded) {
+      setPinnedExpanded(true)
+      const lastIdx = pinnedItems.length - 1
+      setFocusedIndex(lastIdx)
+      setTimeout(() => historyItemRefs.current[lastIdx]?.focus(), 0)
+      return true
+    }
+    return false
+  }, [showSections, pinnedExpanded, pinnedItems.length])
+
+  const onLeftArrow = useCallback(() => {
+    if (showSections && pinnedExpanded && focusedIndex < pinnedItems.length) {
+      setPinnedExpanded(false)
+      setFocusedIndex(0)
+      setTimeout(() => historyItemRefs.current[0]?.focus(), 0)
+    }
+  }, [showSections, pinnedExpanded, focusedIndex, pinnedItems.length])
+
   // Keyboard navigation
   useHistoryKeyboardNavigation({
-    activeTab: 'clipboard', // Always 'clipboard' when this component is mounted
-    itemsLength: filteredHistory.length,
+    activeTab: 'clipboard',
+    itemsLength: visibleItems.length,
     focusedIndex,
     setFocusedIndex,
     historyItemRefs,
     tabBarRef,
+    onUpFromFirstItem,
+    onLeftArrow,
   })
 
   // Ref for stable access to filtered history in event listener
@@ -268,7 +308,6 @@ export function ClipboardTab(props: {
         isCompact={isCompact}
         onToggleCompact={() => setIsCompact(!isCompact)}
       />
-      {/* Search Bar - only visible when Ctrl+F is pressed */}
       {isSearchVisible && (
         <div className="px-3 pb-2 pt-1">
           <SearchBar
@@ -296,24 +335,54 @@ export function ClipboardTab(props: {
               isDark ? 'text-win11-text-secondary' : 'text-win11Light-text-secondary'
             )}
           >
-            No items found
+            {searchQuery ? 'No items found' : 'No clipboard history yet'}
           </p>
         </div>
       ) : (
         <div className="flex flex-col gap-2 p-3" role="listbox" aria-label="Clipboard history">
-          {filteredHistory.map((item, index) => (
+          {showSections && (
+            <button
+              onClick={() => {
+                const willCollapse = pinnedExpanded
+                setPinnedExpanded(!pinnedExpanded)
+                if (willCollapse) {
+                  setFocusedIndex(0)
+                  setTimeout(() => historyItemRefs.current[0]?.focus(), 0)
+                }
+              }}
+              className={clsx(
+                'flex items-center gap-1.5 px-1 py-1 text-xs font-medium',
+                'dark:text-win11-text-tertiary text-win11Light-text-tertiary',
+                'hover:dark:text-win11-text-secondary hover:text-win11Light-text-secondary',
+                'rounded transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-win11-bg-accent'
+              )}
+              aria-expanded={pinnedExpanded}
+            >
+              <Pin size={12} />
+              <span>Pinned</span>
+              <span className="ml-auto opacity-60">{pinnedItems.length}</span>
+              <ChevronDown
+                size={12}
+                className={clsx(
+                  'transition-transform duration-150',
+                  !pinnedExpanded && '-rotate-90'
+                )}
+              />
+            </button>
+          )}
+          {pinnedExpanded && pinnedItems.map((item, offset) => (
             <HistoryItem
               key={item.id}
               ref={(el) => {
-                historyItemRefs.current[index] = el
+                historyItemRefs.current[offset] = el
               }}
               item={item}
-              index={index}
-              isFocused={index === focusedIndex}
+              index={offset}
+              isFocused={offset === focusedIndex}
               onPaste={onPaste}
               onDelete={deleteItem}
               onTogglePin={togglePin}
-              onFocus={() => setFocusedIndex(index)}
+              onFocus={() => setFocusedIndex(offset)}
               isDark={isDark}
               secondaryOpacity={secondaryOpacity}
               isCompact={isCompact}
@@ -321,6 +390,36 @@ export function ClipboardTab(props: {
               enableUiPolish={settings.enable_ui_polish}
             />
           ))}
+          {showSections && unpinnedItems.length > 0 && (
+            <div className="flex items-center gap-1.5 px-1 py-1 text-xs dark:text-win11-text-tertiary text-win11Light-text-tertiary">
+              <History size={12} />
+              <span>Recent</span>
+              <span className="ml-auto opacity-60">{unpinnedItems.length}</span>
+            </div>
+          )}
+          {unpinnedItems.map((item, offset) => {
+            const idx = showSections && pinnedExpanded ? pinnedItems.length + offset : offset
+            return (
+              <HistoryItem
+                key={item.id}
+                ref={(el) => {
+                  historyItemRefs.current[idx] = el
+                }}
+                item={item}
+                index={idx}
+                isFocused={idx === focusedIndex}
+                onPaste={onPaste}
+                onDelete={deleteItem}
+                onTogglePin={togglePin}
+                onFocus={() => setFocusedIndex(idx)}
+                isDark={isDark}
+                secondaryOpacity={secondaryOpacity}
+                isCompact={isCompact}
+                enableSmartActions={settings.enable_smart_actions}
+                enableUiPolish={settings.enable_ui_polish}
+              />
+            )
+          })}
         </div>
       )}
     </>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import { LayoutList } from 'lucide-react'
 import { getTertiaryBackgroundStyle } from '../utils/themeUtils'
 
 interface HeaderProps {
+  title?: string
   onClearHistory: () => void
   itemCount: number
   isDark: boolean
@@ -17,6 +18,7 @@ interface HeaderProps {
  * Header component with title and action buttons
  */
 export function Header({
+  title = 'Clipboard',
   onClearHistory,
   itemCount,
   isDark,
@@ -38,7 +40,7 @@ export function Header({
             isDark ? 'text-win11-text-primary' : 'text-win11Light-text-primary'
           )}
         >
-          Clipboard
+          {title}
         </h1>
         {itemCount > 0 && (
           <span

--- a/src/hooks/useHistoryKeyboardNavigation.ts
+++ b/src/hooks/useHistoryKeyboardNavigation.ts
@@ -51,8 +51,10 @@ export function useHistoryKeyboardNavigation(params: {
         historyItemRefs.current[newIndex]?.focus()
         historyItemRefs.current[newIndex]?.scrollIntoView({ block: 'nearest' })
       } else if (e.key === 'ArrowLeft') {
-        e.preventDefault()
-        onLeftArrow?.()
+        if (onLeftArrow) {
+          e.preventDefault()
+          onLeftArrow()
+        }
       } else if (e.key === 'Home') {
         e.preventDefault()
         setFocusedIndex(0)

--- a/src/hooks/useHistoryKeyboardNavigation.ts
+++ b/src/hooks/useHistoryKeyboardNavigation.ts
@@ -10,21 +10,28 @@ export function useHistoryKeyboardNavigation(params: {
   setFocusedIndex: (i: number) => void
   historyItemRefs: MutableRefObject<(HTMLElement | null)[]>
   tabBarRef: RefObject<TabBarRef | null>
+  onUpFromFirstItem?: () => boolean
+  onLeftArrow?: () => void
 }) {
-  const { activeTab, itemsLength, focusedIndex, setFocusedIndex, historyItemRefs, tabBarRef } =
-    params
+  const {
+    activeTab,
+    itemsLength,
+    focusedIndex,
+    setFocusedIndex,
+    historyItemRefs,
+    tabBarRef,
+    onUpFromFirstItem,
+    onLeftArrow,
+  } = params
 
   useEffect(() => {
     if (activeTab !== 'clipboard' || itemsLength === 0) return
 
     const handleArrowKeys = (e: KeyboardEvent) => {
-      // Check if a tab button is focused - if so, don't intercept arrows
       const activeElement = document.activeElement
       if (activeElement?.getAttribute('role') === 'tab') return
-      // Check if search bar is focused
       if (activeElement?.tagName === 'INPUT') return
 
-      // Check if focus is on a history item or body
       const isOnHistoryItem =
         historyItemRefs.current.some((ref) => ref === activeElement) ||
         activeElement === document.body
@@ -38,10 +45,14 @@ export function useHistoryKeyboardNavigation(params: {
         historyItemRefs.current[newIndex]?.scrollIntoView({ block: 'nearest' })
       } else if (e.key === 'ArrowUp') {
         e.preventDefault()
+        if (focusedIndex === 0 && onUpFromFirstItem?.()) return
         const newIndex = Math.max(focusedIndex - 1, 0)
         setFocusedIndex(newIndex)
         historyItemRefs.current[newIndex]?.focus()
         historyItemRefs.current[newIndex]?.scrollIntoView({ block: 'nearest' })
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault()
+        onLeftArrow?.()
       } else if (e.key === 'Home') {
         e.preventDefault()
         setFocusedIndex(0)
@@ -54,7 +65,6 @@ export function useHistoryKeyboardNavigation(params: {
         historyItemRefs.current[lastIndex]?.focus()
         historyItemRefs.current[lastIndex]?.scrollIntoView({ block: 'nearest' })
       } else if (e.key === 'Tab' && !e.shiftKey) {
-        // When pressing Tab on a history item, go back to the tab bar
         e.preventDefault()
         tabBarRef.current?.focusFirstTab()
       }
@@ -62,5 +72,5 @@ export function useHistoryKeyboardNavigation(params: {
 
     globalThis.addEventListener('keydown', handleArrowKeys)
     return () => globalThis.removeEventListener('keydown', handleArrowKeys)
-  }, [activeTab, itemsLength, focusedIndex, setFocusedIndex, historyItemRefs, tabBarRef])
+  }, [activeTab, itemsLength, focusedIndex, setFocusedIndex, historyItemRefs, tabBarRef, onUpFromFirstItem, onLeftArrow])
 }


### PR DESCRIPTION
## 📝 Description

<!-- Describe your changes in detail -->
This improves pinned items ux, handling and selection with keyboard:
left-arrow or clic on pinned group: allows collapsing pinned items and navigating faster to recent
up from recent: comes back to pinned items

## 🔗 Related Issue

<!-- Link to the issue this PR addresses (if any) -->
Just think this is helpful and sharing here

## 🧪 Type of Change

<!-- Mark the appropriate option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Chore (build process, dependencies, etc.)

## 📸 Screenshots (if applicable)

<!-- Add screenshots to show UI changes -->
<img width="355" height="477" alt="image" src="https://github.com/user-attachments/assets/a7b9e870-c4f5-413c-a0a4-34ccf19e82e8" />

## ✅ Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format`
- [x] I have tested my changes locally
- [ ] I have added/updated documentation as needed (could do it if accepted)
- [x] My changes don't introduce new warnings
- [ ] I have tested on both X11 and Wayland (if applicable)

## 🖥️ Testing Environment

- **OS**:  Ubuntu
- **Desktop Environment**:  Genome
- **Display Server**: Wayland

## 📋 Additional Notes

<!-- Add any additional information for reviewers -->

## Summary by Sourcery

Improve clipboard pinned section UX with collapsible sections and enhanced keyboard navigation.

New Features:
- Add collapsible pinned section in the clipboard history with persisted expanded state.
- Introduce distinct pinned and recent sections in the clipboard history list header.
- Allow keyboard navigation to collapse/expand pinned section and move between pinned and recent items using arrow keys.

Enhancements:
- Update clipboard header to support a configurable title prop with a default value.
- Refine search and empty-state messages for clearer clipboard history feedback.