### PR TITLE
refactor: Migrate GIF integration to Klipy and resolve integration & type bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ target/
 # Build outputs
 dist/
 src-tauri/target/
+*.tsbuildinfo
+
 
 # IDE
 .vscode/

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Most Linux clipboard managers are purely functional but lack visual appeal. This
 | **⚡ Instant Access** | Opens instantly with `Super+V` or `Ctrl+Alt+V`. |
 | **🧠 Smart Positioning** | The window follows your mouse cursor across multiple monitors. |
 | **📌 Pin & Sync** | Pin important snippets to keep them at the top. |
-| **🎬 GIF Integration** | Search Tenor and paste GIFs directly into Discord, Slack, etc. |
+| **🎬 GIF Integration** | Search Klipy and paste GIFs directly into Discord, Slack, etc. |
 | **🤩 Emoji Picker** | A built-in, searchable emoji keyboard. |
 | **🛡️ Privacy First** | Your history is stored locally. No data leaves your machine. |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4.2.4",
         "@tauri-apps/cli": "^2.11.0",
+        "@types/babel__core": "^7.20.5",
         "@types/node": "^25.2.3",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.4",
     "@tauri-apps/cli": "^2.11.0",
+    "@types/babel__core": "^7.20.5",
     "@types/node": "^25.2.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/src-tauri/src/clipboard_manager.rs
+++ b/src-tauri/src/clipboard_manager.rs
@@ -99,7 +99,7 @@ impl ClipboardItem {
         let preview = if text.chars().count() > PREVIEW_TEXT_MAX_LEN {
             format!(
                 "{}...",
-                &text.chars().take(PREVIEW_TEXT_MAX_LEN).collect::<String>()
+                text.chars().take(PREVIEW_TEXT_MAX_LEN).collect::<String>()
             )
         } else {
             text.clone()
@@ -112,7 +112,7 @@ impl ClipboardItem {
         let preview = if plain.chars().count() > PREVIEW_TEXT_MAX_LEN {
             format!(
                 "{}...",
-                &plain.chars().take(PREVIEW_TEXT_MAX_LEN).collect::<String>()
+                plain.chars().take(PREVIEW_TEXT_MAX_LEN).collect::<String>()
             )
         } else {
             plain.clone()

--- a/src-tauri/src/input_simulator.rs
+++ b/src-tauri/src/input_simulator.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 type PasteStrategy = (&'static str, fn() -> Result<(), String>);
 
 /// Delay before starting the paste sequence to ensure window focus is stable
-const PRE_PASTE_DELAY_MS: u64 = 1;
+const PRE_PASTE_DELAY_MS: u64 = 50;
 
 /// Delay between key events to ensure proper registration
 const KEY_EVENT_DELAY_MS: u64 = 50;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -249,13 +249,7 @@ async fn paste_gif_from_url(
     Ok(())
 }
 
-#[tauri::command]
-async fn finish_paste(app: AppHandle) -> Result<(), String> {
-    WindowController::hide(&app);
-    PasteHelper::prepare_target_window().await?;
-    simulate_paste_keystroke().map_err(|e| e.to_string())?;
-    Ok(())
-}
+
 
 #[tauri::command]
 async fn copy_text_to_clipboard(_state: State<'_, AppState>, text: String) -> Result<(), String> {
@@ -1019,7 +1013,6 @@ fn main() {
             paste_text,
             get_recent_emojis,
             paste_gif_from_url,
-            finish_paste,
             finish_setup, // Register the new command
             set_mouse_state,
             get_user_settings,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -126,6 +126,11 @@ fn is_settings_window_visible(app: AppHandle) -> bool {
         .unwrap_or(false)
 }
 
+#[tauri::command]
+fn open_settings_window(app: AppHandle) {
+    SettingsController::show(&app);
+}
+
 // --- Theme Detection Commands ---
 
 /// Get system color scheme from XDG Desktop Portal (supports COSMIC and other modern DEs)
@@ -248,8 +253,6 @@ async fn paste_gif_from_url(
 
     Ok(())
 }
-
-
 
 #[tauri::command]
 async fn copy_text_to_clipboard(_state: State<'_, AppState>, text: String) -> Result<(), String> {
@@ -1018,6 +1021,7 @@ fn main() {
             get_user_settings,
             set_user_settings,
             is_settings_window_visible,
+            open_settings_window,
             copy_text_to_clipboard,
             get_system_theme,
             refresh_system_theme,

--- a/src-tauri/src/user_settings.rs
+++ b/src-tauri/src/user_settings.rs
@@ -53,6 +53,11 @@ pub struct UserSettings {
     /// UI scale factor for the clipboard window (0.5 to 2.0, default 1.0)
     #[serde(default = "default_ui_scale")]
     pub ui_scale: f32,
+
+    // --- API Keys ---
+    /// API key for Klipy GIF service
+    #[serde(default)]
+    pub klipy_api_key: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -97,6 +102,7 @@ impl Default for UserSettings {
             auto_delete_unit: "hours".to_string(),
             custom_kaomojis: Vec::new(),
             ui_scale: default_ui_scale(),
+            klipy_api_key: "".to_string(),
         }
     }
 }

--- a/src/ClipboardApp.tsx
+++ b/src/ClipboardApp.tsx
@@ -14,23 +14,10 @@ import { SymbolPicker } from './components/SymbolPicker'
 import { calculateSecondaryOpacity, calculateTertiaryOpacity } from './utils/themeUtils'
 import { useSystemThemePreference } from './utils/systemTheme'
 import { useRenderingEnv } from './hooks/useRenderingEnv'
+import { DEFAULT_SETTINGS } from './types/clipboard'
 import type { ActiveTab, UserSettings } from './types/clipboard'
 import { ClipboardTab } from './components/ClipboardTab'
 
-const DEFAULT_SETTINGS: UserSettings = {
-  theme_mode: 'system',
-  dark_background_opacity: 0.7,
-  light_background_opacity: 0.7,
-  enable_smart_actions: true,
-  enable_ui_polish: true,
-  enable_dynamic_tray_icon: true,
-  max_history_size: 50,
-  auto_delete_interval: 0,
-  auto_delete_unit: 'hours',
-  custom_kaomojis: [],
-  ui_scale: 1,
-  klipy_api_key: '',
-}
 
 /**
  * Maps theme mode setting to actual dark mode state.

--- a/src/ClipboardApp.tsx
+++ b/src/ClipboardApp.tsx
@@ -29,6 +29,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   auto_delete_unit: 'hours',
   custom_kaomojis: [],
   ui_scale: 1,
+  klipy_api_key: '',
 }
 
 /**

--- a/src/SettingsApp.tsx
+++ b/src/SettingsApp.tsx
@@ -6,6 +6,7 @@ import { emit } from '@tauri-apps/api/event'
 import { clsx } from 'clsx'
 import { Eye, EyeOff } from 'lucide-react'
 
+import { DEFAULT_SETTINGS } from './types/clipboard'
 import type { UserSettings, CustomKaomoji, BooleanSettingKey } from './types/clipboard'
 import { FeaturesSection } from './components/FeaturesSection'
 import { Switch } from './components/Switch'
@@ -15,20 +16,6 @@ import { useRenderingEnv } from './hooks/useRenderingEnv'
 const MIN_HISTORY_SIZE = 1
 const MAX_HISTORY_SIZE = 100_000
 
-const DEFAULT_SETTINGS: UserSettings = {
-  theme_mode: 'system',
-  dark_background_opacity: 0.7,
-  light_background_opacity: 0.7,
-  enable_smart_actions: true,
-  enable_ui_polish: true,
-  enable_dynamic_tray_icon: true,
-  max_history_size: 50,
-  custom_kaomojis: [],
-  ui_scale: 1,
-  auto_delete_interval: 0,
-  auto_delete_unit: 'hours',
-  klipy_api_key: '',
-}
 
 type ThemeMode = 'system' | 'dark' | 'light'
 

--- a/src/SettingsApp.tsx
+++ b/src/SettingsApp.tsx
@@ -4,6 +4,7 @@ import { getCurrentWindow, Window } from '@tauri-apps/api/window'
 import { listen } from '@tauri-apps/api/event'
 import { emit } from '@tauri-apps/api/event'
 import { clsx } from 'clsx'
+import { Eye, EyeOff } from 'lucide-react'
 
 import type { UserSettings, CustomKaomoji, BooleanSettingKey } from './types/clipboard'
 import { FeaturesSection } from './components/FeaturesSection'
@@ -26,6 +27,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   ui_scale: 1,
   auto_delete_interval: 0,
   auto_delete_unit: 'hours',
+  klipy_api_key: '',
 }
 
 type ThemeMode = 'system' | 'dark' | 'light'
@@ -291,6 +293,9 @@ function SettingsApp() {
 
   // Custom Kaomoji State
   const [newKaomoji, setNewKaomoji] = useState('')
+
+  // Show/Hide API Key State
+  const [showApiKey, setShowApiKey] = useState(false)
 
   // Rendering environment (NVIDIA / AppImage detection)
   const renderingEnv = useRenderingEnv()
@@ -933,6 +938,80 @@ function SettingsApp() {
                     : 'bg-gray-50 border-gray-200 text-gray-900'
                 )}
               />
+            </div>
+          </div>
+        </section>
+
+        {/* GIF Search Settings Section */}
+        <section
+          className={clsx(
+            'rounded-xl border shadow-sm overflow-hidden',
+            isDark ? 'bg-win11-bg-secondary border-white/5' : 'bg-white border-gray-200/60'
+          )}
+        >
+          <div className="p-6 border-b border-inherit">
+            <h2 className="text-base font-semibold mb-1">GIF Search Settings</h2>
+            <p className={clsx('text-xs', isDark ? 'text-gray-400' : 'text-gray-500')}>
+              Configure Klipy GIF API credentials
+            </p>
+          </div>
+
+          <div className="p-6 space-y-4">
+            <div className="space-y-2">
+              <label htmlFor="klipy-api-key" className="text-sm font-medium block">
+                Klipy API Key
+              </label>
+              <div className="relative flex items-center">
+                <input
+                  id="klipy-api-key"
+                  type={showApiKey ? 'text' : 'password'}
+                  value={settings.klipy_api_key || ''}
+                  onChange={(e) => updateSettings({ klipy_api_key: e.target.value })}
+                  placeholder="Enter your Klipy API Key"
+                  className={clsx(
+                    'w-full pl-3 pr-10 py-2 rounded-md border text-sm focus:outline-none focus:ring-2 focus:ring-win11-bg-accent/50 transition-all font-mono',
+                    isDark
+                      ? 'bg-white/5 border-white/10 text-white placeholder-gray-500'
+                      : 'bg-gray-50 border-gray-200 text-gray-900 placeholder-gray-400'
+                  )}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowApiKey(!showApiKey)}
+                  className={clsx(
+                    'absolute right-3 p-1 rounded-md transition-colors',
+                    isDark
+                      ? 'text-gray-400 hover:text-white hover:bg-white/5'
+                      : 'text-gray-500 hover:text-gray-900 hover:bg-gray-100'
+                  )}
+                  title={showApiKey ? 'Hide API Key' : 'Show API Key'}
+                >
+                  {showApiKey ? <EyeOff size={16} /> : <Eye size={16} />}
+                </button>
+              </div>
+              <div className={clsx('text-xs space-y-1.5 leading-normal mt-2', isDark ? 'text-gray-400' : 'text-gray-500')}>
+                <p>
+                  Since the Tenor API has been discontinued, you need a free Klipy API Key to use the GIF search features.
+                </p>
+                <ol className="list-decimal list-inside space-y-1 pl-1">
+                  <li>
+                    Sign up or log in at the{' '}
+                    <a
+                      href="https://partner.klipy.com"
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-win11-bg-accent hover:underline"
+                    >
+                      Klipy Partner Panel
+                    </a>
+                    .
+                  </li>
+                  <li>
+                    Navigate to <strong>API Keys</strong> and click <strong>Add Platform</strong> to generate your key.
+                  </li>
+                  <li>Copy and paste the key into the input field above.</li>
+                </ol>
+              </div>
             </div>
           </div>
         </section>

--- a/src/components/GifPicker.tsx
+++ b/src/components/GifPicker.tsx
@@ -298,8 +298,8 @@ export function GifPicker({ isDark, opacity }: GifPickerProps) {
           value={searchQuery}
           onChange={(val: string) => setSearchQuery(val)}
           onClear={handleClearSearch}
-          placeholder="Search Tenor GIFs..."
-          aria-label="Search Tenor GIFs"
+          placeholder="Search Klipy GIFs..."
+          aria-label="Search Klipy GIFs"
           isDark={isDark}
           opacity={opacity}
           rightActions={
@@ -340,7 +340,7 @@ export function GifPicker({ isDark, opacity }: GifPickerProps) {
       footer={
         <div className="w-full text-center">
           <span className="text-[10px] dark:text-win11-text-disabled text-win11Light-text-disabled">
-            Powered by Tenor
+            Powered by Klipy
           </span>
         </div>
       }

--- a/src/components/GifPicker.tsx
+++ b/src/components/GifPicker.tsx
@@ -1,5 +1,6 @@
 import { useState, memo, useRef, useCallback } from 'react'
 import { Grid, useGridRef } from 'react-window'
+import { invoke } from '@tauri-apps/api/core'
 import { clsx } from 'clsx'
 import { Search, RefreshCw, TrendingUp } from 'lucide-react'
 import { useGifPicker } from '../hooks/useGifPicker'
@@ -246,6 +247,32 @@ export function GifPicker({ isDark, opacity }: GifPickerProps) {
   const renderGridContent = () => {
     if (isLoading && gifs.length === 0) {
       return <LoadingSkeleton />
+    }
+
+    if (error === 'MISSING_API_KEY') {
+      return (
+        <div className="flex flex-col items-center justify-center h-full py-12 px-6 text-center animate-fade-in">
+          <div className="w-12 h-12 rounded-full dark:bg-win11-bg-tertiary bg-win11Light-bg-tertiary flex items-center justify-center mb-4">
+            <Search className="w-6 h-6 dark:text-win11-text-secondary text-win11Light-text-secondary" />
+          </div>
+          <h3 className="text-sm font-semibold dark:text-win11-text-primary text-win11Light-text-primary mb-2">
+            Klipy API Key Required
+          </h3>
+          <p className="text-xs dark:text-win11-text-secondary text-win11Light-text-secondary mb-6 max-w-[240px]">
+            To search and paste GIFs, please configure your free Klipy API Key in settings.
+          </p>
+          <button
+            onClick={() => invoke('open_settings_window').catch(console.error)}
+            className={clsx(
+              'px-4 py-2 rounded-lg text-xs font-semibold text-white bg-win11-bg-accent',
+              'hover:opacity-90 transition-opacity duration-150 shadow-md',
+              'focus:outline-none focus:ring-2 focus:ring-win11-bg-accent/50'
+            )}
+          >
+            Configure in Settings
+          </button>
+        </div>
+      )
     }
 
     if (error) {

--- a/src/hooks/useGifPicker.ts
+++ b/src/hooks/useGifPicker.ts
@@ -99,21 +99,11 @@ export function useGifPicker() {
   const pasteGif = useCallback(async (gif: Gif) => {
     setIsPasting(true)
     try {
-      // 1. Download and copy to clipboard
+      // 1. Download, copy to clipboard, and paste
       await invoke('paste_gif_from_url', { url: gif.fullUrl })
 
-      // 2. Reset loading state BEFORE hiding window
+      // 2. Reset loading state
       setIsPasting(false)
-
-      // 3. Finish paste sequence (hide window, simulate Ctrl+V)
-      // We use a small timeout to ensure the UI update has painted
-      setTimeout(async () => {
-        try {
-          await invoke('finish_paste')
-        } catch (err) {
-          console.error('Failed to finish paste:', err)
-        }
-      }, 100)
     } catch (err) {
       console.error('Failed to paste GIF:', err)
       setIsPasting(false)

--- a/src/hooks/useGifPicker.ts
+++ b/src/hooks/useGifPicker.ts
@@ -41,7 +41,10 @@ export function useGifPicker() {
     } catch (err) {
       console.error('Failed to fetch GIFs:', err)
       if (isMountedRef.current) {
-        setError(err instanceof Error ? err.message : 'Failed to load GIFs')
+        const msg = err instanceof Error ? err.message : ''
+        setError(
+          msg.includes('Klipy API Key is not configured') ? 'MISSING_API_KEY' : (msg || 'Failed to load GIFs')
+        )
         setGifs([])
       }
     } finally {

--- a/src/services/gifService.ts
+++ b/src/services/gifService.ts
@@ -1,47 +1,35 @@
 /**
  * GIF Service
- * Handles fetching GIFs from Tenor API v1
+ * Handles fetching GIFs from Klipy API v2 (Tenor compatible)
  */
-import type { Gif } from '../types/gif'
+import { invoke } from '@tauri-apps/api/core'
+import type { Gif, KlipyGifResult, KlipySearchResponse } from '../types/gif'
+import type { UserSettings } from '../types/clipboard'
 
-const TENOR_API_KEY = 'LIVDSRZULELA'
-const TENOR_API_BASE = 'https://g.tenor.com/v1'
+const KLIPY_API_BASE = 'https://api.klipy.com/v2'
 const DEFAULT_LIMIT = 30
+const KLIPY_MEDIA_FILTER = 'gif,tinygif,nanogif,mediumgif'
 
-interface TenorV1MediaFormat {
-  url: string
-  dims: [number, number]
-  size: number
+/**
+ * Dynamically retrieves the user's Klipy API key from settings.
+ */
+async function getKlipyApiKey(): Promise<string> {
+  try {
+    const settings = await invoke<UserSettings>('get_user_settings')
+    return settings.klipy_api_key?.trim() || ''
+  } catch (err) {
+    console.error('[gifService] Failed to load user settings for API key:', err)
+    return ''
+  }
 }
 
-interface TenorV1Media {
-  gif?: TenorV1MediaFormat
-  mediumgif?: TenorV1MediaFormat
-  tinygif?: TenorV1MediaFormat
-  nanogif?: TenorV1MediaFormat
-}
-
-interface TenorV1Result {
-  id: string
-  title: string
-  media: TenorV1Media[]
-  content_description?: string
-  itemurl: string
-  url: string
-  tags: string[]
-  created: number
-}
-
-interface TenorV1Response {
-  results: TenorV1Result[]
-  next: string
-}
-
-function transformTenorResult(result: TenorV1Result): Gif {
-  // v1 API has media as an array, get the first item
-  const mediaFormats = result.media[0]
+/**
+ * Transforms a Klipy V2 API result into our app's internal Gif structure.
+ */
+function transformKlipyResult(result: KlipyGifResult): Gif {
+  const mediaFormats = result.media_formats
   if (!mediaFormats) {
-    throw new Error(`Missing media for GIF: ${result.id}`)
+    throw new Error(`Missing media formats for GIF: ${result.id}`)
   }
 
   // Use nanogif for preview (smallest size for grid)
@@ -64,27 +52,32 @@ function transformTenorResult(result: TenorV1Result): Gif {
 }
 
 /**
- * Fetch trending GIFs from Tenor
+ * Fetch trending GIFs from Klipy
  */
 export async function fetchTrendingGifs(limit: number = DEFAULT_LIMIT): Promise<Gif[]> {
-  const params = new URLSearchParams({
-    key: TENOR_API_KEY,
-    limit: String(limit),
-    media_filter: 'minimal',
-  })
-
-  const response = await fetch(`${TENOR_API_BASE}/trending?${params}`)
-
-  if (!response.ok) {
-    throw new Error(`Tenor API error: ${response.status} ${response.statusText}`)
+  const apiKey = await getKlipyApiKey()
+  if (!apiKey) {
+    throw new Error('Klipy API Key is not configured. Please set it in Settings.')
   }
 
-  const data: TenorV1Response = await response.json()
+  const params = new URLSearchParams({
+    key: apiKey,
+    limit: String(limit),
+    media_filter: KLIPY_MEDIA_FILTER,
+  })
 
-  return data.results
+  const response = await fetch(`${KLIPY_API_BASE}/featured?${params}`)
+
+  if (!response.ok) {
+    throw new Error(`Klipy API error: ${response.status} ${response.statusText}`)
+  }
+
+  const data: KlipySearchResponse = await response.json()
+
+  return (data.results || [])
     .map((result) => {
       try {
-        return transformTenorResult(result)
+        return transformKlipyResult(result)
       } catch {
         console.warn(`Skipping malformed GIF result: ${result.id}`)
         return null
@@ -97,29 +90,34 @@ export async function fetchTrendingGifs(limit: number = DEFAULT_LIMIT): Promise<
  * Search GIFs by query
  */
 export async function searchGifs(query: string, limit: number = DEFAULT_LIMIT): Promise<Gif[]> {
+  const apiKey = await getKlipyApiKey()
+  if (!apiKey) {
+    throw new Error('Klipy API Key is not configured. Please set it in Settings.')
+  }
+
   if (!query.trim()) {
     return fetchTrendingGifs(limit)
   }
 
   const params = new URLSearchParams({
-    key: TENOR_API_KEY,
+    key: apiKey,
     q: query.trim(),
     limit: String(limit),
-    media_filter: 'minimal',
+    media_filter: KLIPY_MEDIA_FILTER,
   })
 
-  const response = await fetch(`${TENOR_API_BASE}/search?${params}`)
+  const response = await fetch(`${KLIPY_API_BASE}/search?${params}`)
 
   if (!response.ok) {
-    throw new Error(`Tenor API error: ${response.status} ${response.statusText}`)
+    throw new Error(`Klipy API error: ${response.status} ${response.statusText}`)
   }
 
-  const data: TenorV1Response = await response.json()
+  const data: KlipySearchResponse = await response.json()
 
-  return data.results
+  return (data.results || [])
     .map((result) => {
       try {
-        return transformTenorResult(result)
+        return transformKlipyResult(result)
       } catch {
         console.warn(`Skipping malformed GIF result: ${result.id}`)
         return null

--- a/src/types/clipboard.ts
+++ b/src/types/clipboard.ts
@@ -78,6 +78,22 @@ export interface UserSettings {
   klipy_api_key: string
 }
 
+export const DEFAULT_SETTINGS: UserSettings = {
+  theme_mode: 'system',
+  dark_background_opacity: 0.7,
+  light_background_opacity: 0.7,
+  enable_smart_actions: true,
+  enable_ui_polish: true,
+  enable_dynamic_tray_icon: true,
+  max_history_size: 50,
+  auto_delete_interval: 0,
+  auto_delete_unit: 'hours',
+  custom_kaomojis: [],
+  ui_scale: 1,
+  klipy_api_key: '',
+}
+
+
 /** Helper type for boolean settings keys */
 export type BooleanSettingKey = {
   [K in keyof UserSettings]: UserSettings[K] extends boolean ? K : never

--- a/src/types/clipboard.ts
+++ b/src/types/clipboard.ts
@@ -75,6 +75,7 @@ export interface UserSettings {
   auto_delete_unit: 'minutes' | 'hours' | 'days' | 'weeks'
   custom_kaomojis: CustomKaomoji[]
   ui_scale: number
+  klipy_api_key: string
 }
 
 /** Helper type for boolean settings keys */

--- a/src/types/gif.ts
+++ b/src/types/gif.ts
@@ -1,10 +1,10 @@
 /**
  * GIF Types
- * TypeScript interfaces for Tenor API responses and GIF data
+ * TypeScript interfaces for Klipy API responses and GIF data
  */
 
-/** Media format from Tenor API */
-export interface TenorMediaFormat {
+/** Media format from Klipy API */
+export interface KlipyMediaFormat {
   url: string
   dims: [number, number]
   duration?: number
@@ -12,25 +12,25 @@ export interface TenorMediaFormat {
 }
 
 /** Media formats available for a GIF */
-export interface TenorMediaFormats {
-  gif?: TenorMediaFormat
-  mediumgif?: TenorMediaFormat
-  tinygif?: TenorMediaFormat
-  nanogif?: TenorMediaFormat
-  mp4?: TenorMediaFormat
-  loopedmp4?: TenorMediaFormat
-  tinymp4?: TenorMediaFormat
-  nanomp4?: TenorMediaFormat
-  webm?: TenorMediaFormat
-  tinywebm?: TenorMediaFormat
-  nanowebm?: TenorMediaFormat
+export interface KlipyMediaFormats {
+  gif?: KlipyMediaFormat
+  mediumgif?: KlipyMediaFormat
+  tinygif?: KlipyMediaFormat
+  nanogif?: KlipyMediaFormat
+  mp4?: KlipyMediaFormat
+  loopedmp4?: KlipyMediaFormat
+  tinymp4?: KlipyMediaFormat
+  nanomp4?: KlipyMediaFormat
+  webm?: KlipyMediaFormat
+  tinywebm?: KlipyMediaFormat
+  nanowebm?: KlipyMediaFormat
 }
 
-/** Single GIF result from Tenor API */
-export interface TenorGifResult {
+/** Single GIF result from Klipy API */
+export interface KlipyGifResult {
   id: string
   title: string
-  media_formats: TenorMediaFormats
+  media_formats: KlipyMediaFormats
   content_description: string
   itemurl: string
   url: string
@@ -38,9 +38,9 @@ export interface TenorGifResult {
   created: number
 }
 
-/** Tenor API response for search/trending */
-export interface TenorSearchResponse {
-  results: TenorGifResult[]
+/** Klipy API response for search/trending */
+export interface KlipySearchResponse {
+  results: KlipyGifResult[]
   next: string
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "types": [],
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
### Summary
This PR migrates the application's GIF picker integration from the discontinued Tenor V1 API to **Klipy V2** (Tenor-compatible API), adds settings support for configuring a Klipy API key, and resolves three bugs encountered during integration.

### Changes
1. **Tenor to Klipy Migration**:
   - Updated types and service implementation (`src/types/gif.ts`, `src/services/gifService.ts`) to conform to the Klipy V2 API response structures.
   - Added `klipy_api_key` to user settings (`src/types/clipboard.ts`, `src-tauri/src/user_settings.rs`).
   - Added a settings field in `src/SettingsApp.tsx` for users to enter their Klipy API key.

2. **Bugs Resolved**:
   - **Types Resolution Bug (`babel__core`)**: Added `"types": []` to `tsconfig.json` to prevent TypeScript from scanning and implicitly loading all packages in `@types` (e.g. `@types/babel__core`). This fixes the `Cannot find type definition file for 'babel__core'` error that happens in environments where the workspace path has non-ASCII characters.
   - **Klipy Trend/Featured Endpoint (`SyntaxError`)**: Changed the endpoint for trending GIFs from `/v2/trending` (which returned a blank HTML page) to `/v2/featured` (the correct Tenor-v2 compatible route). This resolves the `SyntaxError: The string did not match the expected pattern` when parsing the response.
   - **Double Paste Bug**: Removed the redundant call to `finish_paste` from `src/hooks/useGifPicker.ts` and deleted the command from the Tauri backend (`src-tauri/src/main.rs`). The backend `paste_gif_from_url` already hides the window and simulates the paste keystroke; calling `finish_paste` 100ms later resulted in pasting the GIF twice.

### Discussion: Distributing the App Without Forcing Users to Provide an API Key
Currently, the integration is configured to require users to register on Klipy and paste their own API key into the application settings. To avoid forcing end-users to do this, we can consider the following options for the official release:
1. **Attributed Production Key (Recommended):**
   We can apply to upgrade our current Test Key to a **Production Key** via the Klipy partner dashboard (which is free but requires a screen recording of the app displaying the "Powered by Klipy" attribution logo). Once approved, we can bundle this Production Key directly in the app code to give all users unlimited, out-of-the-box access without requiring them to set up an account.
2. **Fallback / Bundled Test Key:**
   We can bundle a default public Test Key in the app. However, if the 100 requests/hour limit is key-wide (rather than IP-wide), users might hit the limit frequently.
3. **API Proxy Server:**
   We could route the GIF searches through a small serverless proxy function. This proxy would append the API key to requests, keeping the key hidden and allowing us to implement caching to save bandwidth.

## Summary by Sourcery

Migrate GIF integration from the deprecated Tenor API to Klipy, add configurable Klipy API key support, and fix related GIF paste and typing issues.

New Features:
- Integrate GIF search with the Klipy v2 API instead of Tenor, including updated response types and media handling.
- Add a new Klipy API key field in user settings and expose it via a dedicated GIF Search Settings section in the settings UI, with show/hide controls and usage instructions.

Bug Fixes:
- Ensure trending GIFs use the correct Klipy /v2/featured endpoint to avoid invalid HTML responses and syntax errors.
- Prevent GIFs from being pasted twice by removing the redundant finish_paste command and relying solely on paste_gif_from_url.
- Avoid TypeScript type resolution errors (e.g. for babel__core) by explicitly configuring the tsconfig types list and adding the @types/babel__core dev dependency.

Enhancements:
- Update all GIF-related types, labels, and attributions across the app and documentation to reference Klipy instead of Tenor.

Build:
- Adjust TypeScript configuration and dependencies to stabilize type resolution behavior in diverse environments.