### PR TITLE
fix: disable GIF integration due to Tenor API discontinuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Most Linux clipboard managers are purely functional but lack visual appeal. This
 | **⚡ Instant Access** | Opens instantly with `Super+V` or `Ctrl+Alt+V`. |
 | **🧠 Smart Positioning** | The window follows your mouse cursor across multiple monitors. |
 | **📌 Pin & Sync** | Pin important snippets to keep them at the top. |
-| **🎬 GIF Integration** | Search Tenor and paste GIFs directly into Discord, Slack, etc. |
+| **🎬 ~~GIF Integration~~** | ~~Search Tenor and paste GIFs directly into Discord, Slack, etc.~~ **Disabled:** [Google killed the Tenor GIF API](https://arstechnica.com/gadgets/2026/06/google-kills-tenor-gif-api-forcing-changes-at-x-discord-and-more/). |
 | **🤩 Emoji Picker** | A built-in, searchable emoji keyboard. |
 | **🛡️ Privacy First** | Your history is stored locally. No data leaves your machine. |
 
@@ -58,7 +58,7 @@ Most Linux clipboard managers are purely functional but lack visual appeal. This
 | <kbd>Enter</kbd> | Paste Selected Item |
 | <kbd>Esc</kbd> | Close Window |
 
-> **Pro Tip:** Need to paste a GIF? Just select it! The app simulates `Ctrl+V` to paste the file URI directly into your chat apps.
+> ~~**Pro Tip:** Need to paste a GIF? Just select it!~~ **The GIF tab is currently disabled because Google killed the Tenor API.** The implementation remains in the source tree so a sustainable provider can be integrated later. [Read what happened](https://arstechnica.com/gadgets/2026/06/google-kills-tenor-gif-api-forcing-changes-at-x-discord-and-more/).
 
 ---
 

--- a/src/ClipboardApp.tsx
+++ b/src/ClipboardApp.tsx
@@ -8,7 +8,6 @@ import { useClipboardHistory } from './hooks/useClipboardHistory'
 import { TabBar, TabBarRef } from './components/TabBar'
 import { DragHandle } from './components/DragHandle'
 import { EmojiPicker } from './components/EmojiPicker'
-import { GifPicker } from './components/GifPicker'
 import { KaomojiPicker } from './components/KaomojiPicker'
 import { SymbolPicker } from './components/SymbolPicker'
 import { calculateSecondaryOpacity, calculateTertiaryOpacity } from './utils/themeUtils'
@@ -144,7 +143,7 @@ function ClipboardApp() {
     // Listen for switch-tab events from Rust (e.g., when Super+. is pressed)
     const unlistenSwitchTab = listen<string>('switch-tab', (event) => {
       const tabName = event.payload as ActiveTab
-      if (['clipboard', 'emoji', 'gifs', 'kaomoji', 'symbols'].includes(tabName)) {
+      if (['clipboard', 'emoji', 'kaomoji', 'symbols'].includes(tabName)) {
         setActiveTab(tabName)
       }
     })
@@ -259,8 +258,8 @@ function ClipboardApp() {
       case 'emoji':
         return <EmojiPicker isDark={isDark} opacity={secondaryOpacity} />
 
-      case 'gifs':
-        return <GifPicker isDark={isDark} opacity={secondaryOpacity} />
+      // case 'gifs':
+      //   return <GifPicker isDark={isDark} opacity={secondaryOpacity} />
 
       case 'kaomoji':
         return (
@@ -315,7 +314,7 @@ function ClipboardApp() {
           'flex-1',
           // Only use scrollbar for non-emoji/gif/kaomoji tabs, they have their own virtualized scrolling or containers
           activeTab === 'emoji' ||
-            activeTab === 'gifs' ||
+            // activeTab === 'gifs' ||
             activeTab === 'kaomoji' ||
             activeTab === 'symbols'
             ? 'overflow-hidden'

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useRef, useImperativeHandle, useCallback, useState } from 'react'
 import { clsx } from 'clsx'
-import { ClipboardList, Smile, Image, Type, Omega } from 'lucide-react'
+import { ClipboardList, Smile, Type, Omega } from 'lucide-react'
 import type { ActiveTab } from '../types/clipboard'
 
 import { getTertiaryBackgroundStyle } from '../utils/themeUtils'
@@ -21,7 +21,7 @@ const ALL_TABS: { id: ActiveTab; label: string; icon: typeof ClipboardList }[] =
   { id: 'symbols', label: 'Symbols', icon: Omega },
   { id: 'emoji', label: 'Emoji', icon: Smile },
   { id: 'kaomoji', label: 'Kaomoji', icon: Type },
-  { id: 'gifs', label: 'GIFs', icon: Image },
+  // { id: 'gifs', label: 'GIFs', icon: Image },
 ]
 
 export const TabBar = forwardRef<TabBarRef, TabBarProps>(function TabBar(

--- a/src/types/clipboard.ts
+++ b/src/types/clipboard.ts
@@ -39,7 +39,8 @@ export interface ClipboardItem {
 }
 
 /** Active tab in the UI */
-export type ActiveTab = 'clipboard' | 'gifs' | 'emoji' | 'kaomoji' | 'symbols'
+// export type ActiveTab = 'clipboard' | 'gifs' | 'emoji' | 'kaomoji' | 'symbols'
+export type ActiveTab = 'clipboard' | 'emoji' | 'kaomoji' | 'symbols'
 
 /** Theme mode */
 export type ThemeMode = 'light' | 'dark' | 'system'


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Document the GIF integration as disabled and explain the Tenor API shutdown and future re-enablement plans.


https://github.com/gustavosett/Windows-11-Clipboard-History-For-Linux/issues/277