### PR TITLE
fix: lazy loading

### DIFF
--- a/src-tauri/src/clipboard_manager.rs
+++ b/src-tauri/src/clipboard_manager.rs
@@ -11,7 +11,7 @@ use std::hash::{Hash, Hasher};
 use std::io::Cursor;
 use std::path::PathBuf;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 // --- Constants ---
@@ -20,7 +20,8 @@ pub const DEFAULT_MAX_HISTORY_SIZE: usize = 50;
 const PREVIEW_TEXT_MAX_LEN: usize = 100;
 const GIF_CACHE_MARKER: &str = "win11-clipboard-history/gifs/";
 const FILE_URI_PREFIX: &str = "file://";
-const WL_COPY_SETTLE_TIME: u64 = 150;
+const CLIPBOARD_HELPER_READY_TIMEOUT: Duration = Duration::from_secs(2);
+const CLIPBOARD_HELPER_POLL_INTERVAL: Duration = Duration::from_millis(2);
 
 // --- Helper Functions ---
 
@@ -696,9 +697,13 @@ impl ClipboardManager {
     }
 
     fn simulate_paste_action(&self) -> Result<(), String> {
-        // Wait for the clipboard write to settle: confirmed via the X11
-        // selection owner when possible, same fixed sleep otherwise.
-        crate::paste_sync::settle_clipboard_owned(Duration::from_millis(60));
+        // Wayland helpers already acknowledge readiness in
+        // set_clipboard_external. On X11, ownership is directly observable.
+        if crate::session::is_x11()
+            && !crate::paste_sync::settle_clipboard_owned(Duration::from_millis(500))
+        {
+            return Err("Clipboard ownership was not confirmed before paste".to_string());
+        }
 
         // Trigger keystroke
         crate::input_simulator::simulate_paste_keystroke()?;
@@ -786,13 +791,28 @@ impl ClipboardManager {
                 .map_err(|e| format!("Pipe write error: {}", e))?;
         }
 
-        // Wait for the helper to actually acquire the selection, polling the
-        // real X11 CLIPBOARD owner instead of sleeping a fixed delay.
-        // Sleeps the same fixed delay as before when unverifiable (Wayland).
-        crate::paste_sync::settle_clipboard_handoff(
+        if cmd == "wl-copy" {
+            // wl-copy's foreground parent exits only after the Wayland
+            // selection was installed. Waiting for that exit is an adaptive
+            // readiness acknowledgement: immediate on a fast compositor and
+            // longer only while a constrained compositor is still working.
+            return wait_for_clipboard_helper_ready(&mut child, cmd);
+        }
+
+        // On X11, selection ownership is directly observable. A timeout is a
+        // failed precondition, not permission to emit an unverified Ctrl+V.
+        let handoff_confirmed = crate::paste_sync::settle_clipboard_handoff(
             owner_before,
-            Duration::from_millis(WL_COPY_SETTLE_TIME),
+            CLIPBOARD_HELPER_READY_TIMEOUT,
         );
+        if !handoff_confirmed {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(format!(
+                "{} did not acquire the clipboard selection within {:?}",
+                cmd, CLIPBOARD_HELPER_READY_TIMEOUT
+            ));
+        }
 
         match child.try_wait() {
             Ok(Some(status)) if !status.success() => {
@@ -808,16 +828,57 @@ impl ClipboardManager {
                 ))
             }
             Ok(_) => {
-                // If it's still running or exited successfully, we assume it worked.
-                // For xclip/wl-copy, they often background themselves or stay alive to serve content.
-                if cmd == "xclip" {
-                    thread::spawn(move || {
-                        let _ = child.wait();
-                    });
-                }
+                // xclip remains alive to serve selection requests. Reap it in
+                // the background after another application takes ownership.
+                thread::spawn(move || {
+                    let _ = child.wait();
+                });
                 Ok(())
             }
             Err(e) => Err(format!("Process status check failed: {}", e)),
+        }
+    }
+}
+
+/// Waits for helpers such as wl-copy whose parent process exits after the
+/// clipboard selection is ready. The child serving the selection has already
+/// forked by then, so waiting for the parent does not shorten clipboard life.
+fn wait_for_clipboard_helper_ready(
+    child: &mut std::process::Child,
+    command: &str,
+) -> Result<(), String> {
+    use std::io::Read;
+
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) if status.success() => return Ok(()),
+            Ok(Some(status)) => {
+                let mut stderr = String::new();
+                if let Some(mut pipe) = child.stderr.take() {
+                    let _ = pipe.read_to_string(&mut stderr);
+                }
+                return Err(format!(
+                    "{} exited with status {}. Stderr: {}",
+                    command,
+                    status,
+                    stderr.trim()
+                ));
+            }
+            Ok(None) if start.elapsed() < CLIPBOARD_HELPER_READY_TIMEOUT => {
+                thread::sleep(CLIPBOARD_HELPER_POLL_INTERVAL);
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!(
+                    "{} did not confirm clipboard readiness within {:?}",
+                    command, CLIPBOARD_HELPER_READY_TIMEOUT
+                ));
+            }
+            Err(error) => {
+                return Err(format!("Failed to inspect {} status: {}", command, error));
+            }
         }
     }
 }

--- a/src-tauri/src/clipboard_manager.rs
+++ b/src-tauri/src/clipboard_manager.rs
@@ -659,8 +659,7 @@ impl ClipboardManager {
                 width,
                 height,
             } => {
-                let mut clipboard = get_system_clipboard()?;
-                self.write_image_to_clipboard(&mut clipboard, base64, *width, *height)?;
+                self.set_image_robust(base64, *width, *height)?;
             }
         }
 
@@ -673,16 +672,33 @@ impl ClipboardManager {
         Ok(())
     }
 
-    fn write_image_to_clipboard(
-        &self,
-        clipboard: &mut Clipboard,
-        base64_str: &str,
-        width: u32,
-        height: u32,
-    ) -> Result<(), String> {
+    fn set_image_robust(&self, base64_str: &str, width: u32, height: u32) -> Result<(), String> {
         let bytes = BASE64
             .decode(base64_str)
             .map_err(|e| format!("Base64 decode failed: {}", e))?;
+
+        #[cfg(target_os = "linux")]
+        {
+            if crate::session::is_wayland() {
+                if self
+                    .set_clipboard_external("wl-copy", &["--type", "image/png"], &bytes)
+                    .is_ok()
+                {
+                    return Ok(());
+                }
+            } else if self
+                .set_clipboard_external(
+                    "xclip",
+                    &["-selection", "clipboard", "-t", "image/png"],
+                    &bytes,
+                )
+                .is_ok()
+            {
+                return Ok(());
+            }
+        }
+
+        let mut clipboard = get_system_clipboard()?;
         let img =
             image::load_from_memory(&bytes).map_err(|e| format!("Image load failed: {}", e))?;
         let rgba = img.to_rgba8();
@@ -697,21 +713,10 @@ impl ClipboardManager {
     }
 
     fn simulate_paste_action(&self) -> Result<(), String> {
-        // Wayland helpers already acknowledge readiness in
-        // set_clipboard_external. On X11, ownership is directly observable.
-        if crate::session::is_x11()
-            && !crate::paste_sync::settle_clipboard_owned(Duration::from_millis(500))
-        {
-            return Err("Clipboard ownership was not confirmed before paste".to_string());
-        }
-
-        // Trigger keystroke
-        crate::input_simulator::simulate_paste_keystroke()?;
-
-        // before the clipboard ownership changes or the app reads it.
-        thread::sleep(Duration::from_millis(250));
-
-        Ok(())
+        // Clipboard writers return only after their platform-specific
+        // readiness barrier. The serving process (or arboard's global worker)
+        // outlives this call, so no fixed post-paste retention is necessary.
+        crate::input_simulator::simulate_paste_keystroke()
     }
 
     /// Robustly set text to clipboard using xclip/wl-copy on Linux if available,
@@ -723,14 +728,14 @@ impl ClipboardManager {
                 if let Ok(()) = self.set_clipboard_external(
                     "wl-copy",
                     &["--type", "text/plain;charset=utf-8"],
-                    text,
+                    text.as_bytes(),
                 ) {
                     return Ok(());
                 }
             } else if let Ok(()) = self.set_clipboard_external(
                 "xclip",
                 &["-selection", "clipboard", "-t", "UTF8_STRING"],
-                text,
+                text.as_bytes(),
             ) {
                 return Ok(());
             }
@@ -747,16 +752,18 @@ impl ClipboardManager {
         #[cfg(target_os = "linux")]
         {
             if crate::session::is_wayland() {
-                if let Ok(()) =
-                    self.set_clipboard_external("wl-copy", &["--type", "text/html"], html)
-                {
+                if let Ok(()) = self.set_clipboard_external(
+                    "wl-copy",
+                    &["--type", "text/html"],
+                    html.as_bytes(),
+                ) {
                     let _ = self.set_text_robust(plain);
                     return Ok(());
                 }
             } else if let Ok(()) = self.set_clipboard_external(
                 "xclip",
                 &["-selection", "clipboard", "-t", "text/html"],
-                html,
+                html.as_bytes(),
             ) {
                 let _ = self.set_text_robust(plain);
                 return Ok(());
@@ -770,7 +777,7 @@ impl ClipboardManager {
             .map_err(|e| e.to_string())
     }
 
-    fn set_clipboard_external(&self, cmd: &str, args: &[&str], data: &str) -> Result<(), String> {
+    fn set_clipboard_external(&self, cmd: &str, args: &[&str], data: &[u8]) -> Result<(), String> {
         use std::io::{Read, Write};
         use std::process::{Command, Stdio};
 
@@ -787,7 +794,7 @@ impl ClipboardManager {
 
         if let Some(mut stdin) = child.stdin.take() {
             stdin
-                .write_all(data.as_bytes())
+                .write_all(data)
                 .map_err(|e| format!("Pipe write error: {}", e))?;
         }
 

--- a/src-tauri/src/clipboard_manager.rs
+++ b/src-tauri/src/clipboard_manager.rs
@@ -100,7 +100,7 @@ impl ClipboardItem {
         let preview = if text.chars().count() > PREVIEW_TEXT_MAX_LEN {
             format!(
                 "{}...",
-                &text.chars().take(PREVIEW_TEXT_MAX_LEN).collect::<String>()
+                text.chars().take(PREVIEW_TEXT_MAX_LEN).collect::<String>()
             )
         } else {
             text.clone()
@@ -113,7 +113,7 @@ impl ClipboardItem {
         let preview = if plain.chars().count() > PREVIEW_TEXT_MAX_LEN {
             format!(
                 "{}...",
-                &plain.chars().take(PREVIEW_TEXT_MAX_LEN).collect::<String>()
+                plain.chars().take(PREVIEW_TEXT_MAX_LEN).collect::<String>()
             )
         } else {
             plain.clone()
@@ -702,20 +702,33 @@ impl ClipboardManager {
         let img =
             image::load_from_memory(&bytes).map_err(|e| format!("Image load failed: {}", e))?;
         let rgba = img.to_rgba8();
+        let expected_bytes = rgba.into_raw();
 
         let image_data = ImageData {
             width: width as usize,
             height: height as usize,
-            bytes: rgba.into_raw().into(),
+            bytes: expected_bytes.clone().into(),
         };
 
-        clipboard.set_image(image_data).map_err(|e| e.to_string())
+        clipboard.set_image(image_data).map_err(|e| e.to_string())?;
+
+        // Reading through the same arboard instance performs the backend
+        // round trip that confirms our provider owns and serves the selection.
+        let observed = clipboard.get_image().map_err(|e| e.to_string())?;
+        if observed.width != width as usize
+            || observed.height != height as usize
+            || observed.bytes.as_ref() != expected_bytes.as_slice()
+        {
+            return Err("Clipboard image verification returned different data".to_string());
+        }
+
+        Ok(())
     }
 
     fn simulate_paste_action(&self) -> Result<(), String> {
         // Clipboard writers return only after their platform-specific
-        // readiness barrier. The serving process (or arboard's global worker)
-        // outlives this call, so no fixed post-paste retention is necessary.
+        // readiness barrier. The serving process (or arboard's verified global
+        // worker) outlives this call, so no fixed post-paste retention is needed.
         crate::input_simulator::simulate_paste_keystroke()
     }
 
@@ -743,7 +756,12 @@ impl ClipboardManager {
 
         // Fallback to arboard
         let mut clipboard = get_system_clipboard()?;
-        clipboard.set_text(text).map_err(|e| e.to_string())
+        clipboard.set_text(text).map_err(|e| e.to_string())?;
+        let observed = clipboard.get_text().map_err(|e| e.to_string())?;
+        if observed != text {
+            return Err("Clipboard text verification returned different data".to_string());
+        }
+        Ok(())
     }
 
     /// Robustly set HTML to clipboard using xclip/wl-copy on Linux if available,
@@ -774,7 +792,12 @@ impl ClipboardManager {
         let mut clipboard = get_system_clipboard()?;
         clipboard
             .set_html(html, Some(plain))
-            .map_err(|e| e.to_string())
+            .map_err(|e| e.to_string())?;
+        let observed = clipboard.get().html().map_err(|e| e.to_string())?;
+        if observed != html {
+            return Err("Clipboard HTML verification returned different data".to_string());
+        }
+        Ok(())
     }
 
     fn set_clipboard_external(&self, cmd: &str, args: &[&str], data: &[u8]) -> Result<(), String> {

--- a/src-tauri/src/focus_manager.rs
+++ b/src-tauri/src/focus_manager.rs
@@ -8,8 +8,10 @@ use std::time::{Duration, Instant};
 use x11rb::connection::Connection;
 use x11rb::protocol::xproto::{AtomEnum, ClientMessageEvent, ConnectionExt, EventMask, InputFocus};
 
-/// Time to wait after restoring focus before allowing the paste to proceed
-const FOCUS_RESTORE_DELAY: Duration = Duration::from_millis(150);
+/// Failure ceiling for focus restoration. Fast systems return after two
+/// confirmed samples; constrained systems are allowed more time without
+/// imposing that time on every paste.
+const FOCUS_RESTORE_TIMEOUT: Duration = Duration::from_millis(750);
 
 /// Stores the ID of the window that had focus before we opened
 static LAST_FOCUSED_WINDOW: AtomicU32 = AtomicU32::new(0);
@@ -48,9 +50,8 @@ pub fn restore_focused_window() -> Result<bool, String> {
     conn.flush().map_err(|e| format!("Flush failed: {}", e))?;
 
     // Wait for the Window Manager to actually process the focus change,
-    // polling the real focus state instead of sleeping a fixed delay.
-    // If unverifiable, settle_focus sleeps the same fixed delay as before.
-    let confirmed = crate::paste_sync::settle_focus(window_id, FOCUS_RESTORE_DELAY);
+    // requiring a stable observed state instead of sleeping a fixed delay.
+    let confirmed = crate::paste_sync::settle_focus(window_id, FOCUS_RESTORE_TIMEOUT);
 
     Ok(confirmed)
 }

--- a/src-tauri/src/focus_manager.rs
+++ b/src-tauri/src/focus_manager.rs
@@ -21,6 +21,11 @@ pub fn save_focused_window() {
         return;
     }
 
+    // Never reuse a target captured for an older popup invocation if this
+    // query fails. Pasting nowhere is safer than redirecting input to a stale
+    // application window.
+    LAST_FOCUSED_WINDOW.store(0, Ordering::SeqCst);
+
     match crate::paste_sync::focused_window() {
         Some(window_id) => {
             LAST_FOCUSED_WINDOW.store(window_id, Ordering::SeqCst);

--- a/src-tauri/src/focus_manager.rs
+++ b/src-tauri/src/focus_manager.rs
@@ -17,19 +17,16 @@ const FOCUS_RESTORE_TIMEOUT: Duration = Duration::from_millis(750);
 static LAST_FOCUSED_WINDOW: AtomicU32 = AtomicU32::new(0);
 
 pub fn save_focused_window() {
-    match get_x11_connection() {
-        Ok(conn) => match conn.get_input_focus() {
-            Ok(cookie) => match cookie.reply() {
-                Ok(reply) => {
-                    let window_id = reply.focus;
-                    LAST_FOCUSED_WINDOW.store(window_id, Ordering::SeqCst);
-                    eprintln!("[FocusManager] Saved focused window: {}", window_id);
-                }
-                Err(e) => eprintln!("[FocusManager] Failed to get focus reply: {}", e),
-            },
-            Err(e) => eprintln!("[FocusManager] Failed to request input focus: {}", e),
-        },
-        Err(e) => eprintln!("[FocusManager] X11 Connection failed: {}", e),
+    if !crate::session::is_x11() {
+        return;
+    }
+
+    match crate::paste_sync::focused_window() {
+        Some(window_id) => {
+            LAST_FOCUSED_WINDOW.store(window_id, Ordering::SeqCst);
+            eprintln!("[FocusManager] Saved focused window: {}", window_id);
+        }
+        None => eprintln!("[FocusManager] Failed to query the focused X11 window"),
     }
 }
 
@@ -42,35 +39,11 @@ pub fn restore_focused_window() -> Result<bool, String> {
 
     eprintln!("[FocusManager] Restoring focus to window: {}", window_id);
 
-    let conn = get_x11_connection()?;
-
-    conn.set_input_focus(InputFocus::PARENT, window_id, x11rb::CURRENT_TIME)
-        .map_err(|e| format!("Set focus failed: {}", e))?;
-
-    conn.flush().map_err(|e| format!("Flush failed: {}", e))?;
-
-    // Wait for the Window Manager to actually process the focus change,
-    // requiring a stable observed state instead of sleeping a fixed delay.
-    let confirmed = crate::paste_sync::settle_focus(window_id, FOCUS_RESTORE_TIMEOUT);
-
-    Ok(confirmed)
+    crate::paste_sync::restore_and_settle_focus(window_id, FOCUS_RESTORE_TIMEOUT)
 }
 
 pub fn get_focused_window() -> Option<u32> {
-    let conn = get_x11_connection().ok()?;
-
-    // Split the chain to satisfy the borrow checker (fix for E0597)
-    let cookie = conn.get_input_focus().ok()?;
-    let reply = cookie.reply().ok()?;
-
-    Some(reply.focus)
-}
-
-/// Helper to establish X11 connection
-fn get_x11_connection() -> Result<impl Connection, String> {
-    x11rb::connect(None)
-        .map(|(conn, _)| conn)
-        .map_err(|e| format!("X11 connect failed: {}", e))
+    crate::paste_sync::focused_window()
 }
 
 // =============================================================================

--- a/src-tauri/src/input_simulator.rs
+++ b/src-tauri/src/input_simulator.rs
@@ -1,33 +1,101 @@
 use crate::session;
-use std::thread;
-use std::time::Duration;
+use parking_lot::Mutex;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::os::fd::AsRawFd;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
 
 type PasteStrategy = (&'static str, fn() -> Result<(), String>);
 
-/// Delay before starting the paste sequence to ensure window focus is stable
-const PRE_PASTE_DELAY_MS: u64 = 1;
+/// The kernel creates a uinput device synchronously, but udev/libinput and the
+/// compositor discover it asynchronously. Device readiness is paid once at
+/// startup, never for every paste.
+const DEVICE_READY_TIMEOUT: Duration = Duration::from_secs(2);
+const DEVICE_READY_POLL_INTERVAL: Duration = Duration::from_millis(5);
+const DEVICE_DISCOVERY_GRACE: Duration = Duration::from_millis(100);
 
-/// Delay between key events to ensure proper registration
-const KEY_EVENT_DELAY_MS: u64 = 50;
+/// X11 key-state checks are round trips to the X server. They normally finish
+/// immediately; the timeout is only a failure ceiling for a stalled server.
+const X11_KEY_STATE_TIMEOUT: Duration = Duration::from_millis(250);
+const X11_KEY_STATE_POLL_INTERVAL: Duration = Duration::from_millis(1);
 
-/// Delay after device creation for uinput to be recognized
-const UINPUT_DEVICE_SETTLE_MS: u64 = 50;
+/// Kept only for the last-resort xdotool fallback. The primary XTest path
+/// verifies the actual key state and needs no fixed inter-key delay.
+const XDOTOOL_KEY_DELAY_MS: &str = "50";
 
-/// Delay after paste sequence completes
-const POST_PASTE_DELAY_MS: u64 = 1;
+const EV_SYN: u16 = 0x00;
+const EV_KEY: u16 = 0x01;
+const SYN_REPORT: u16 = 0x00;
+const KEY_LEFTCTRL: u16 = 29;
+const KEY_V: u16 = 47;
+
+const UI_SET_EVBIT: libc::c_ulong = 0x40045564;
+const UI_SET_KEYBIT: libc::c_ulong = 0x40045565;
+const UI_DEV_SETUP: libc::c_ulong = 0x405c5503;
+const UI_DEV_CREATE: libc::c_ulong = 0x5501;
+const UI_DEV_DESTROY: libc::c_ulong = 0x5502;
+
+const X11_KEY_PRESS: u8 = 2;
+const X11_KEY_RELEASE: u8 = 3;
+const XK_CONTROL_L: u32 = 0xffe3;
+const XK_CONTROL_R: u32 = 0xffe4;
+const XK_LOWER_V: u32 = 0x0076;
+const XK_UPPER_V: u32 = 0x0056;
+
+/// Persistent virtual keyboard. Recreating it for every paste allowed the
+/// compositor to attach after Ctrl but before V, which produced a literal
+/// `v` under load.
+struct UinputDevice {
+    file: File,
+}
+
+static UINPUT_DEVICE: OnceLock<Mutex<Option<UinputDevice>>> = OnceLock::new();
+
+/// Starts uinput discovery outside the paste hot path. If startup happens
+/// before permissions are granted, the first paste retries initialization.
+pub fn init() {
+    if session::is_x11() {
+        return;
+    }
+
+    if let Err(error) = std::thread::Builder::new()
+        .name("uinput-paste-warmup".to_string())
+        .spawn(|| {
+            let mut device = uinput_device_lock().lock();
+            if device.is_some() {
+                return;
+            }
+
+            match UinputDevice::create() {
+                Ok(created) => {
+                    *device = Some(created);
+                    eprintln!("[uinput] Virtual keyboard warmed up at startup");
+                }
+                Err(error) => {
+                    eprintln!(
+                        "[uinput] Startup warmup failed; first paste will retry: {}",
+                        error
+                    );
+                }
+            }
+        })
+    {
+        eprintln!("[uinput] Failed to start warmup thread: {}", error);
+    }
+}
 
 pub fn simulate_paste_keystroke() -> Result<(), String> {
-    // Give window manager time to settle focus before sending keystrokes
-    thread::sleep(Duration::from_millis(PRE_PASTE_DELAY_MS));
-
     eprintln!("[SimulatePaste] Sending Ctrl+V...");
 
+    // XTest uses one native X11 connection and verifies that Ctrl is down
+    // before V. xdotool is retained only as a compatibility fallback.
     const X11_STRATEGIES: &[PasteStrategy] = &[
-        ("xdotool", simulate_paste_xdotool),
         ("XTest", simulate_paste_xtest),
+        ("xdotool", simulate_paste_xdotool),
         ("uinput", simulate_paste_uinput),
     ];
-
     const NON_X11_STRATEGIES: &[PasteStrategy] = &[("uinput", simulate_paste_uinput)];
 
     let strategies = if session::is_x11() {
@@ -36,237 +104,516 @@ pub fn simulate_paste_keystroke() -> Result<(), String> {
         NON_X11_STRATEGIES
     };
 
-    for (name, func) in strategies {
-        match func() {
+    for (name, strategy) in strategies {
+        match strategy() {
             Ok(()) => {
                 eprintln!("[SimulatePaste] Ctrl+V sent via {}", name);
-                // Small delay after paste to let the target app process it
-                thread::sleep(Duration::from_millis(POST_PASTE_DELAY_MS));
                 return Ok(());
             }
-            Err(err) => {
-                eprintln!("[SimulatePaste] {} failed: {}", name, err);
-            }
+            Err(error) => eprintln!("[SimulatePaste] {} failed: {}", name, error),
         }
     }
 
     Err("All paste methods failed".to_string())
 }
 
-/// Helper for XTest input generation
+// =============================================================================
+// X11 / XTest
+// =============================================================================
+
 fn fake_key<C: x11rb::connection::Connection + x11rb::protocol::xtest::ConnectionExt>(
     conn: &C,
     key_type: u8,
     keycode: u8,
     root_window: u32,
-    ctx: &str,
+    context: &str,
 ) -> Result<(), String> {
     conn.xtest_fake_input(key_type, keycode, 0, root_window, 0, 0, 0)
-        .map_err(|e| format!("{}: {}", ctx, e))?;
-    conn.flush().map_err(|e| format!("Flush failed: {}", e))?;
-    Ok(())
+        .map_err(|error| format!("{}: {}", context, error))?;
+    conn.flush()
+        .map_err(|error| format!("X11 flush failed: {}", error))
 }
 
-/// Simulate Ctrl+V using X11 XTest extension
 fn simulate_paste_xtest() -> Result<(), String> {
     use x11rb::connection::Connection;
     use x11rb::protocol::xtest::ConnectionExt as XtestConnectionExt;
-    use x11rb::wrapper::ConnectionExt as WrapperConnectionExt; // Imported for sync()
-
-    const CTRL_L_KEYCODE: u8 = 37;
-    const V_KEYCODE: u8 = 55;
 
     let (conn, screen_num) =
-        x11rb::connect(None).map_err(|e| format!("X11 connect failed: {}", e))?;
-    let screen = &conn.setup().roots[screen_num];
-    let root_window = screen.root;
+        x11rb::connect(None).map_err(|error| format!("X11 connect failed: {}", error))?;
+    let root_window = conn
+        .setup()
+        .roots
+        .get(screen_num)
+        .ok_or("X11 screen not found")?
+        .root;
 
     conn.xtest_get_version(2, 1)
-        .map_err(|e| format!("XTest version query failed: {}", e))?
+        .map_err(|error| format!("XTest version query failed: {}", error))?
         .reply()
-        .map_err(|e| format!("XTest version query failed: {}", e))?;
+        .map_err(|error| format!("XTest version query failed: {}", error))?;
 
-    conn.sync()
-        .map_err(|e| format!("Sync setup failed: {}", e))?;
+    let (ctrl_keycode, v_keycode) = resolve_paste_keycodes(&conn)?;
+    let mut ctrl_down = false;
+    let mut v_down = false;
 
-    // Press Ctrl and wait for it to be registered
-    fake_key(
-        &conn,
-        2,
-        CTRL_L_KEYCODE,
-        root_window,
-        "Failed to press Ctrl",
-    )?;
-    conn.sync()
-        .map_err(|e| format!("Sync after Ctrl press failed: {}", e))?;
-    thread::sleep(Duration::from_millis(KEY_EVENT_DELAY_MS));
+    let operation = (|| {
+        fake_key(
+            &conn,
+            X11_KEY_PRESS,
+            ctrl_keycode,
+            root_window,
+            "Failed to press Ctrl",
+        )?;
+        ctrl_down = true;
+        wait_for_x11_key_state(&conn, ctrl_keycode, true)?;
 
-    // Press V
-    fake_key(&conn, 2, V_KEYCODE, root_window, "Failed to press V")?;
-    conn.sync()
-        .map_err(|e| format!("Sync after V press failed: {}", e))?;
-    thread::sleep(Duration::from_millis(KEY_EVENT_DELAY_MS));
+        fake_key(
+            &conn,
+            X11_KEY_PRESS,
+            v_keycode,
+            root_window,
+            "Failed to press V",
+        )?;
+        v_down = true;
+        wait_for_x11_key_state(&conn, v_keycode, true)?;
 
-    // Release V
-    fake_key(&conn, 3, V_KEYCODE, root_window, "Failed to release V")?;
-    conn.sync()
-        .map_err(|e| format!("Sync after V release failed: {}", e))?;
-    thread::sleep(Duration::from_millis(KEY_EVENT_DELAY_MS));
+        fake_key(
+            &conn,
+            X11_KEY_RELEASE,
+            v_keycode,
+            root_window,
+            "Failed to release V",
+        )?;
+        v_down = false;
 
-    // Release Ctrl
-    fake_key(
-        &conn,
-        3,
-        CTRL_L_KEYCODE,
-        root_window,
-        "Failed to release Ctrl",
-    )?;
+        fake_key(
+            &conn,
+            X11_KEY_RELEASE,
+            ctrl_keycode,
+            root_window,
+            "Failed to release Ctrl",
+        )?;
+        ctrl_down = false;
 
-    conn.sync()
-        .map_err(|e| format!("Final sync failed: {}", e))?;
-    Ok(())
+        wait_for_x11_key_state(&conn, v_keycode, false)?;
+        wait_for_x11_key_state(&conn, ctrl_keycode, false)
+    })();
+
+    // Never leave a synthetic modifier held if a round trip fails midway.
+    let mut cleanup_errors = Vec::new();
+    if v_down {
+        if let Err(error) = fake_key(
+            &conn,
+            X11_KEY_RELEASE,
+            v_keycode,
+            root_window,
+            "Cleanup failed to release V",
+        ) {
+            cleanup_errors.push(error);
+        }
+    }
+    if ctrl_down {
+        if let Err(error) = fake_key(
+            &conn,
+            X11_KEY_RELEASE,
+            ctrl_keycode,
+            root_window,
+            "Cleanup failed to release Ctrl",
+        ) {
+            cleanup_errors.push(error);
+        }
+    }
+
+    match (operation, cleanup_errors.is_empty()) {
+        (Ok(()), true) => Ok(()),
+        (Ok(()), false) => Err(cleanup_errors.join("; ")),
+        (Err(error), true) => Err(error),
+        (Err(error), false) => Err(format!("{}; {}", error, cleanup_errors.join("; "))),
+    }
 }
 
-/// Simulate Ctrl+V using xdotool
+fn resolve_paste_keycodes<C: x11rb::connection::Connection>(conn: &C) -> Result<(u8, u8), String> {
+    use x11rb::protocol::xproto::ConnectionExt as XprotoConnectionExt;
+
+    let setup = conn.setup();
+    let first_keycode = setup.min_keycode;
+    let keycode_count = u16::from(setup.max_keycode)
+        .checked_sub(u16::from(first_keycode))
+        .and_then(|count| count.checked_add(1))
+        .and_then(|count| u8::try_from(count).ok())
+        .ok_or("Invalid X11 keycode range")?;
+
+    let mapping = conn
+        .get_keyboard_mapping(first_keycode, keycode_count)
+        .map_err(|error| format!("Failed to query X11 keymap: {}", error))?
+        .reply()
+        .map_err(|error| format!("Failed to query X11 keymap: {}", error))?;
+
+    let ctrl = find_keycode(
+        &mapping.keysyms,
+        mapping.keysyms_per_keycode,
+        first_keycode,
+        &[XK_CONTROL_L, XK_CONTROL_R],
+    )
+    .ok_or("Ctrl key not found in the active X11 keymap")?;
+    let v = find_keycode(
+        &mapping.keysyms,
+        mapping.keysyms_per_keycode,
+        first_keycode,
+        &[XK_LOWER_V, XK_UPPER_V],
+    )
+    .ok_or("V key not found in the active X11 keymap")?;
+
+    Ok((ctrl, v))
+}
+
+fn find_keycode(
+    keysyms: &[u32],
+    keysyms_per_keycode: u8,
+    first_keycode: u8,
+    wanted: &[u32],
+) -> Option<u8> {
+    let width = usize::from(keysyms_per_keycode);
+    if width == 0 {
+        return None;
+    }
+
+    keysyms
+        .chunks(width)
+        .position(|symbols| symbols.iter().any(|symbol| wanted.contains(symbol)))
+        .and_then(|offset| u8::try_from(offset).ok())
+        .and_then(|offset| first_keycode.checked_add(offset))
+}
+
+fn wait_for_x11_key_state<C: x11rb::connection::Connection>(
+    conn: &C,
+    keycode: u8,
+    expected_pressed: bool,
+) -> Result<(), String> {
+    use x11rb::protocol::xproto::ConnectionExt as XprotoConnectionExt;
+
+    let start = Instant::now();
+    loop {
+        let reply = conn
+            .query_keymap()
+            .map_err(|error| format!("Failed to query X11 key state: {}", error))?
+            .reply()
+            .map_err(|error| format!("Failed to query X11 key state: {}", error))?;
+
+        if key_is_pressed(&reply.keys, keycode) == expected_pressed {
+            return Ok(());
+        }
+        if start.elapsed() >= X11_KEY_STATE_TIMEOUT {
+            return Err(format!(
+                "Timed out waiting for X11 key {} to become {}",
+                keycode,
+                if expected_pressed {
+                    "pressed"
+                } else {
+                    "released"
+                }
+            ));
+        }
+        std::thread::sleep(X11_KEY_STATE_POLL_INTERVAL);
+    }
+}
+
+fn key_is_pressed(keymap: &[u8; 32], keycode: u8) -> bool {
+    let byte = usize::from(keycode / 8);
+    let bit = keycode % 8;
+    keymap[byte] & (1 << bit) != 0
+}
+
 fn simulate_paste_xdotool() -> Result<(), String> {
-    // Send Ctrl+V to the currently focused window without specifying a target
     let output = std::process::Command::new("xdotool")
-        .arg("key")
-        .arg("--clearmodifiers")
-        .arg("ctrl+v")
+        .args([
+            "key",
+            "--delay",
+            XDOTOOL_KEY_DELAY_MS,
+            "--clearmodifiers",
+            "ctrl+v",
+        ])
         .output()
-        .map_err(|e| format!("Failed to run xdotool key: {}", e))?;
+        .map_err(|error| format!("Failed to run xdotool: {}", error))?;
 
     if output.status.success() {
-        eprintln!("[SimulatePaste] xdotool sent ctrl+v to focused window");
         Ok(())
     } else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        Err(format!("xdotool key failed: {}", stderr))
+        Err(format!(
+            "xdotool failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
     }
 }
 
-fn simulate_paste_uinput() -> Result<(), String> {
-    use std::fs::OpenOptions;
-    use std::io::Write;
-    use std::os::unix::io::AsRawFd;
+// =============================================================================
+// Wayland / uinput
+// =============================================================================
 
-    const EV_SYN: u16 = 0x00;
-    const EV_KEY: u16 = 0x01;
-    const SYN_REPORT: u16 = 0x00;
-    const KEY_LEFTCTRL: u16 = 29;
-    const KEY_V: u16 = 47;
+fn uinput_device_lock() -> &'static Mutex<Option<UinputDevice>> {
+    UINPUT_DEVICE.get_or_init(|| Mutex::new(None))
+}
 
-    fn make_event(type_: u16, code: u16, value: i32) -> [u8; 24] {
-        let mut event = [0u8; 24];
-        event[16..18].copy_from_slice(&type_.to_ne_bytes());
-        event[18..20].copy_from_slice(&code.to_ne_bytes());
-        event[20..24].copy_from_slice(&value.to_ne_bytes());
-        event
-    }
+impl UinputDevice {
+    fn create() -> Result<Self, String> {
+        let file = OpenOptions::new()
+            .write(true)
+            .open("/dev/uinput")
+            .map_err(|error| format!("Failed to open /dev/uinput: {}", error))?;
+        let fd = file.as_raw_fd();
 
-    let mut uinput = OpenOptions::new()
-        .write(true)
-        .open("/dev/uinput")
-        .map_err(|e| format!("Failed to open /dev/uinput: {}", e))?;
-
-    const UI_SET_EVBIT: libc::c_ulong = 0x40045564;
-    const UI_SET_KEYBIT: libc::c_ulong = 0x40045565;
-    const UI_DEV_SETUP: libc::c_ulong = 0x405c5503;
-    const UI_DEV_CREATE: libc::c_ulong = 0x5501;
-    const UI_DEV_DESTROY: libc::c_ulong = 0x5502;
-
-    unsafe {
-        if libc::ioctl(uinput.as_raw_fd(), UI_SET_EVBIT, EV_KEY as libc::c_int) < 0 {
-            return Err("Failed to set EV_KEY".to_string());
-        }
-        if libc::ioctl(
-            uinput.as_raw_fd(),
-            UI_SET_KEYBIT,
-            KEY_LEFTCTRL as libc::c_int,
-        ) < 0
-        {
-            return Err("Failed to set KEY_LEFTCTRL".to_string());
-        }
-        if libc::ioctl(uinput.as_raw_fd(), UI_SET_KEYBIT, KEY_V as libc::c_int) < 0 {
-            return Err("Failed to set KEY_V".to_string());
+        unsafe {
+            if libc::ioctl(fd, UI_SET_EVBIT, EV_KEY as libc::c_int) < 0 {
+                return Err(last_os_error("Failed to enable EV_KEY"));
+            }
+            if libc::ioctl(fd, UI_SET_KEYBIT, KEY_LEFTCTRL as libc::c_int) < 0 {
+                return Err(last_os_error("Failed to enable KEY_LEFTCTRL"));
+            }
+            if libc::ioctl(fd, UI_SET_KEYBIT, KEY_V as libc::c_int) < 0 {
+                return Err(last_os_error("Failed to enable KEY_V"));
+            }
         }
 
         #[repr(C)]
         struct UinputSetup {
-            id: [u16; 4],
+            id: libc::input_id,
             name: [u8; 80],
             ff_effects_max: u32,
         }
 
+        let device_name = format!("win11-clipboard-paste-{}", std::process::id());
         let mut setup = UinputSetup {
-            id: [0x03, 0x1234, 0x5678, 0x0001],
+            id: libc::input_id {
+                bustype: 0x03,
+                vendor: 0x1234,
+                product: 0x5678,
+                version: 0x0001,
+            },
             name: [0; 80],
             ff_effects_max: 0,
         };
-        let name = b"emoji-paste-helper";
-        setup.name[..name.len()].copy_from_slice(name);
+        setup.name[..device_name.len()].copy_from_slice(device_name.as_bytes());
 
-        if libc::ioctl(uinput.as_raw_fd(), UI_DEV_SETUP, &setup) < 0 {
-            return Err("Failed to setup uinput device".to_string());
+        unsafe {
+            if libc::ioctl(fd, UI_DEV_SETUP, &setup) < 0 {
+                return Err(last_os_error("Failed to configure uinput device"));
+            }
+            if libc::ioctl(fd, UI_DEV_CREATE) < 0 {
+                return Err(last_os_error("Failed to create uinput device"));
+            }
         }
-        if libc::ioctl(uinput.as_raw_fd(), UI_DEV_CREATE) < 0 {
-            return Err("Failed to create uinput device".to_string());
+
+        if let Err(error) = wait_for_uinput_device(&device_name) {
+            unsafe {
+                libc::ioctl(fd, UI_DEV_DESTROY);
+            }
+            return Err(error);
+        }
+
+        // The event node is an observable udev barrier. This one-time grace is
+        // outside the hot path after startup and lets the compositor attach.
+        std::thread::sleep(DEVICE_DISCOVERY_GRACE);
+        eprintln!("[uinput] Persistent virtual keyboard is ready");
+
+        Ok(Self { file })
+    }
+
+    fn send_ctrl_v(&mut self) -> Result<(), String> {
+        let sequence = ctrl_v_sequence();
+        if let Err(error) = self.write_events(&sequence) {
+            let _ = self.release_all_keys();
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    fn release_all_keys(&mut self) -> Result<(), String> {
+        self.write_events(&[
+            input_event(EV_KEY, KEY_V, 0),
+            input_event(EV_KEY, KEY_LEFTCTRL, 0),
+            input_event(EV_SYN, SYN_REPORT, 0),
+        ])
+    }
+
+    fn write_events(&mut self, events: &[libc::input_event]) -> Result<(), String> {
+        self.file
+            .write_all(input_events_as_bytes(events))
+            .map_err(|error| format!("Failed to write uinput sequence: {}", error))
+    }
+}
+
+impl Drop for UinputDevice {
+    fn drop(&mut self) {
+        let _ = self.release_all_keys();
+        unsafe {
+            libc::ioctl(self.file.as_raw_fd(), UI_DEV_DESTROY);
+        }
+    }
+}
+
+fn simulate_paste_uinput() -> Result<(), String> {
+    let mut device = uinput_device_lock().lock();
+
+    if let Some(existing) = device.as_mut() {
+        match existing.send_ctrl_v() {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                eprintln!("[uinput] Existing device failed; recreating: {}", error);
+                *device = None;
+            }
         }
     }
 
-    // Wait longer for the virtual device to be recognized by the system
-    // This is critical for some desktop environments (Cinnamon, GNOME)
-    thread::sleep(Duration::from_millis(UINPUT_DEVICE_SETTLE_MS));
-
-    // Press Ctrl
-    uinput
-        .write_all(&make_event(EV_KEY, KEY_LEFTCTRL, 1))
-        .map_err(|e| e.to_string())?;
-    uinput
-        .write_all(&make_event(EV_SYN, SYN_REPORT, 0))
-        .map_err(|e| e.to_string())?;
-    uinput.flush().map_err(|e| e.to_string())?;
-    thread::sleep(Duration::from_millis(KEY_EVENT_DELAY_MS));
-
-    // Press V
-    uinput
-        .write_all(&make_event(EV_KEY, KEY_V, 1))
-        .map_err(|e| e.to_string())?;
-    uinput
-        .write_all(&make_event(EV_SYN, SYN_REPORT, 0))
-        .map_err(|e| e.to_string())?;
-    uinput.flush().map_err(|e| e.to_string())?;
-    thread::sleep(Duration::from_millis(KEY_EVENT_DELAY_MS));
-
-    // Release V
-    uinput
-        .write_all(&make_event(EV_KEY, KEY_V, 0))
-        .map_err(|e| e.to_string())?;
-    uinput
-        .write_all(&make_event(EV_SYN, SYN_REPORT, 0))
-        .map_err(|e| e.to_string())?;
-    uinput.flush().map_err(|e| e.to_string())?;
-    thread::sleep(Duration::from_millis(KEY_EVENT_DELAY_MS));
-
-    // Release Ctrl
-    uinput
-        .write_all(&make_event(EV_KEY, KEY_LEFTCTRL, 0))
-        .map_err(|e| e.to_string())?;
-    uinput
-        .write_all(&make_event(EV_SYN, SYN_REPORT, 0))
-        .map_err(|e| e.to_string())?;
-    uinput.flush().map_err(|e| e.to_string())?;
-
-    // Wait for events to be processed before destroying device
-    thread::sleep(Duration::from_millis(KEY_EVENT_DELAY_MS));
-
-    unsafe {
-        libc::ioctl(uinput.as_raw_fd(), UI_DEV_DESTROY);
-    }
-
-    // Small delay after device destruction
-    thread::sleep(Duration::from_millis(POST_PASTE_DELAY_MS));
-
+    let mut created = UinputDevice::create()?;
+    created.send_ctrl_v()?;
+    *device = Some(created);
     Ok(())
+}
+
+fn ctrl_v_sequence() -> [libc::input_event; 6] {
+    [
+        // One frame makes Ctrl and V visible together; the second releases
+        // both. There is no scheduling window between separate key writes.
+        input_event(EV_KEY, KEY_LEFTCTRL, 1),
+        input_event(EV_KEY, KEY_V, 1),
+        input_event(EV_SYN, SYN_REPORT, 0),
+        input_event(EV_KEY, KEY_V, 0),
+        input_event(EV_KEY, KEY_LEFTCTRL, 0),
+        input_event(EV_SYN, SYN_REPORT, 0),
+    ]
+}
+
+fn input_event(type_: u16, code: u16, value: i32) -> libc::input_event {
+    // input_event has target-specific time fields. Zeroing the libc type uses
+    // the correct ABI on both 32- and 64-bit Linux, unlike a hardcoded 24-byte
+    // buffer.
+    let mut event: libc::input_event = unsafe { std::mem::zeroed() };
+    event.type_ = type_;
+    event.code = code;
+    event.value = value;
+    event
+}
+
+fn input_events_as_bytes(events: &[libc::input_event]) -> &[u8] {
+    // SAFETY: input_event is a plain C ABI struct and the returned byte slice
+    // has exactly the lifetime and initialized size of the source slice.
+    unsafe {
+        std::slice::from_raw_parts(events.as_ptr().cast::<u8>(), std::mem::size_of_val(events))
+    }
+}
+
+fn wait_for_uinput_device(device_name: &str) -> Result<PathBuf, String> {
+    let start = Instant::now();
+    loop {
+        if let Some(path) = find_uinput_event_node(device_name) {
+            eprintln!(
+                "[uinput] Event node {} appeared after {:?}",
+                path.display(),
+                start.elapsed()
+            );
+            return Ok(path);
+        }
+        if start.elapsed() >= DEVICE_READY_TIMEOUT {
+            return Err(format!(
+                "Timed out waiting for '{}' to appear in /dev/input",
+                device_name
+            ));
+        }
+        std::thread::sleep(DEVICE_READY_POLL_INTERVAL);
+    }
+}
+
+fn find_uinput_event_node(device_name: &str) -> Option<PathBuf> {
+    let entries = std::fs::read_dir("/sys/class/input").ok()?;
+    for entry in entries.flatten() {
+        let name = match std::fs::read_to_string(entry.path().join("name")) {
+            Ok(name) => name,
+            Err(_) => continue,
+        };
+        if name.trim() != device_name {
+            continue;
+        }
+
+        let children = match std::fs::read_dir(entry.path()) {
+            Ok(children) => children,
+            Err(_) => continue,
+        };
+        for child in children.flatten() {
+            let file_name = child.file_name();
+            let file_name = file_name.to_string_lossy();
+            if file_name.starts_with("event") {
+                let path = Path::new("/dev/input").join(file_name.as_ref());
+                if path.exists() {
+                    return Some(path);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn last_os_error(context: &str) -> String {
+    format!("{}: {}", context, std::io::Error::last_os_error())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ctrl_v_is_emitted_as_two_complete_frames() {
+        let events = ctrl_v_sequence();
+        let actual: Vec<(u16, u16, i32)> = events
+            .iter()
+            .map(|event| (event.type_, event.code, event.value))
+            .collect();
+
+        assert_eq!(
+            actual,
+            vec![
+                (EV_KEY, KEY_LEFTCTRL, 1),
+                (EV_KEY, KEY_V, 1),
+                (EV_SYN, SYN_REPORT, 0),
+                (EV_KEY, KEY_V, 0),
+                (EV_KEY, KEY_LEFTCTRL, 0),
+                (EV_SYN, SYN_REPORT, 0),
+            ]
+        );
+    }
+
+    #[test]
+    fn input_event_bytes_use_the_platform_abi_size() {
+        let events = ctrl_v_sequence();
+        assert_eq!(
+            input_events_as_bytes(&events).len(),
+            events.len() * std::mem::size_of::<libc::input_event>()
+        );
+    }
+
+    #[test]
+    fn keymap_bit_lookup_handles_keycode_boundaries() {
+        let mut keymap = [0u8; 32];
+        keymap[4] = 1 << 5; // keycode 37
+        keymap[6] = 1 << 7; // keycode 55
+
+        assert!(key_is_pressed(&keymap, 37));
+        assert!(key_is_pressed(&keymap, 55));
+        assert!(!key_is_pressed(&keymap, 36));
+        assert!(!key_is_pressed(&keymap, 56));
+    }
+
+    #[test]
+    fn keycodes_are_resolved_from_the_active_mapping() {
+        // Three keycodes starting at 20, with two symbols each.
+        let mapping = [0, 0, XK_CONTROL_L, 0, XK_LOWER_V, XK_UPPER_V];
+
+        assert_eq!(
+            find_keycode(&mapping, 2, 20, &[XK_CONTROL_L, XK_CONTROL_R]),
+            Some(21)
+        );
+        assert_eq!(
+            find_keycode(&mapping, 2, 20, &[XK_LOWER_V, XK_UPPER_V]),
+            Some(22)
+        );
+    }
 }

--- a/src-tauri/src/input_simulator.rs
+++ b/src-tauri/src/input_simulator.rs
@@ -7,7 +7,14 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
-type PasteStrategy = (&'static str, fn() -> Result<(), String>);
+type PasteStrategy = (&'static str, fn() -> Result<(), PasteFailure>);
+
+enum PasteFailure {
+    /// No paste key was attempted, so another backend may safely run.
+    Retryable(String),
+    /// Input may already have reached the target; retrying could paste twice.
+    Ambiguous(String),
+}
 
 /// The kernel creates a uinput device synchronously, but udev/libinput and the
 /// compositor discover it asynchronously. Device readiness is paid once at
@@ -58,6 +65,16 @@ struct XtestDevice {
     root_window: u32,
     ctrl_keycode: u8,
     v_keycode: u8,
+}
+
+/// Tracks keys before their press request is flushed. This deliberately treats
+/// a flush error as ambiguous: the server may have received the press even
+/// though the client did not receive a successful completion signal.
+struct XtestKeyGuard<'a> {
+    connection: &'a x11rb::rust_connection::RustConnection,
+    root_window: u32,
+    held: Vec<u8>,
+    paste_may_have_been_sent: bool,
 }
 
 static UINPUT_DEVICE: OnceLock<Mutex<Option<UinputDevice>>> = OnceLock::new();
@@ -140,7 +157,15 @@ pub fn simulate_paste_keystroke() -> Result<(), String> {
                 eprintln!("[SimulatePaste] Ctrl+V sent via {}", name);
                 return Ok(());
             }
-            Err(error) => eprintln!("[SimulatePaste] {} failed: {}", name, error),
+            Err(PasteFailure::Retryable(error)) => {
+                eprintln!("[SimulatePaste] {} unavailable: {}", name, error);
+            }
+            Err(PasteFailure::Ambiguous(error)) => {
+                return Err(format!(
+                    "{} failed after input may have been emitted; refusing fallback: {}",
+                    name, error
+                ));
+            }
         }
     }
 
@@ -164,16 +189,17 @@ fn fake_key<C: x11rb::connection::Connection + x11rb::protocol::xtest::Connectio
         .map_err(|error| format!("X11 flush failed: {}", error))
 }
 
-fn simulate_paste_xtest() -> Result<(), String> {
+fn simulate_paste_xtest() -> Result<(), PasteFailure> {
     let mut device = xtest_device_lock().lock();
     if device.is_none() {
-        *device = Some(XtestDevice::create()?);
+        *device = Some(XtestDevice::create().map_err(PasteFailure::Retryable)?);
     }
 
-    let result = device
-        .as_mut()
-        .expect("XTest device was initialized")
-        .send_ctrl_v();
+    let current = device.as_mut().expect("XTest device was initialized");
+    let result = current
+        .refresh_keymap_if_needed()
+        .map_err(PasteFailure::Retryable)
+        .and_then(|()| current.send_ctrl_v());
     if result.is_err() {
         // Reconnect on the next attempt if the X server connection went away.
         *device = None;
@@ -215,84 +241,123 @@ impl XtestDevice {
         })
     }
 
-    fn send_ctrl_v(&mut self) -> Result<(), String> {
-        let mut ctrl_down = false;
-        let mut v_down = false;
+    fn refresh_keymap_if_needed(&mut self) -> Result<(), String> {
+        use x11rb::connection::Connection;
+        use x11rb::protocol::Event;
+
+        let mut mapping_changed = false;
+        while let Some(event) = self
+            .connection
+            .poll_for_event()
+            .map_err(|error| format!("Failed to poll X11 events: {}", error))?
+        {
+            if matches!(event, Event::MappingNotify(_)) {
+                mapping_changed = true;
+            }
+        }
+
+        if mapping_changed {
+            (self.ctrl_keycode, self.v_keycode) = resolve_paste_keycodes(&self.connection)?;
+            eprintln!("[XTest] Keyboard mapping changed; refreshed paste keycodes");
+        }
+
+        Ok(())
+    }
+
+    fn send_ctrl_v(&mut self) -> Result<(), PasteFailure> {
+        let mut guard = XtestKeyGuard::new(&self.connection, self.root_window);
 
         let operation = (|| {
-            fake_key(
-                &self.connection,
-                X11_KEY_PRESS,
-                self.ctrl_keycode,
-                self.root_window,
-                "Failed to press Ctrl",
-            )?;
-            ctrl_down = true;
+            guard.press(self.ctrl_keycode, false, "Failed to press Ctrl")?;
             wait_for_x11_key_state(&self.connection, self.ctrl_keycode, true)?;
 
-            fake_key(
-                &self.connection,
-                X11_KEY_PRESS,
-                self.v_keycode,
-                self.root_window,
-                "Failed to press V",
-            )?;
-            v_down = true;
+            guard.press(self.v_keycode, true, "Failed to press V")?;
             wait_for_x11_key_state(&self.connection, self.v_keycode, true)?;
 
-            fake_key(
-                &self.connection,
-                X11_KEY_RELEASE,
-                self.v_keycode,
-                self.root_window,
-                "Failed to release V",
-            )?;
-            v_down = false;
+            guard.release(self.v_keycode, "Failed to release V")?;
 
-            fake_key(
-                &self.connection,
-                X11_KEY_RELEASE,
-                self.ctrl_keycode,
-                self.root_window,
-                "Failed to release Ctrl",
-            )?;
-            ctrl_down = false;
+            guard.release(self.ctrl_keycode, "Failed to release Ctrl")?;
 
             wait_for_x11_key_state(&self.connection, self.v_keycode, false)?;
             wait_for_x11_key_state(&self.connection, self.ctrl_keycode, false)
         })();
 
-        // Never leave a synthetic modifier held if a round trip fails midway.
-        let mut cleanup_errors = Vec::new();
-        if v_down {
-            if let Err(error) = fake_key(
-                &self.connection,
-                X11_KEY_RELEASE,
-                self.v_keycode,
-                self.root_window,
-                "Cleanup failed to release V",
-            ) {
-                cleanup_errors.push(error);
-            }
-        }
-        if ctrl_down {
-            if let Err(error) = fake_key(
-                &self.connection,
-                X11_KEY_RELEASE,
-                self.ctrl_keycode,
-                self.root_window,
-                "Cleanup failed to release Ctrl",
-            ) {
-                cleanup_errors.push(error);
-            }
-        }
+        let paste_may_have_been_sent = guard.paste_may_have_been_sent;
+        let cleanup_errors = guard.cleanup();
 
         match (operation, cleanup_errors.is_empty()) {
             (Ok(()), true) => Ok(()),
-            (Ok(()), false) => Err(cleanup_errors.join("; ")),
-            (Err(error), true) => Err(error),
-            (Err(error), false) => Err(format!("{}; {}", error, cleanup_errors.join("; "))),
+            (Ok(()), false) => Err(PasteFailure::Ambiguous(cleanup_errors.join("; "))),
+            (Err(error), true) if !paste_may_have_been_sent => Err(PasteFailure::Retryable(error)),
+            (Err(error), true) => Err(PasteFailure::Ambiguous(error)),
+            (Err(error), false) => Err(PasteFailure::Ambiguous(format!(
+                "{}; {}",
+                error,
+                cleanup_errors.join("; ")
+            ))),
         }
+    }
+}
+
+impl<'a> XtestKeyGuard<'a> {
+    fn new(connection: &'a x11rb::rust_connection::RustConnection, root_window: u32) -> Self {
+        Self {
+            connection,
+            root_window,
+            held: Vec::with_capacity(2),
+            paste_may_have_been_sent: false,
+        }
+    }
+
+    fn press(&mut self, keycode: u8, dispatches_paste: bool, context: &str) -> Result<(), String> {
+        // Record intent before flushing so cleanup also covers a request whose
+        // delivery became ambiguous during flush.
+        self.held.push(keycode);
+        self.paste_may_have_been_sent |= dispatches_paste;
+        fake_key(
+            self.connection,
+            X11_KEY_PRESS,
+            keycode,
+            self.root_window,
+            context,
+        )
+    }
+
+    fn release(&mut self, keycode: u8, context: &str) -> Result<(), String> {
+        fake_key(
+            self.connection,
+            X11_KEY_RELEASE,
+            keycode,
+            self.root_window,
+            context,
+        )?;
+        self.held.retain(|held| *held != keycode);
+        Ok(())
+    }
+
+    fn cleanup(&mut self) -> Vec<String> {
+        let mut errors = Vec::new();
+        for keycode in self.held.clone().into_iter().rev() {
+            match fake_key(
+                self.connection,
+                X11_KEY_RELEASE,
+                keycode,
+                self.root_window,
+                "Cleanup failed to release XTest key",
+            ) {
+                Ok(()) => self.held.retain(|held| *held != keycode),
+                Err(error) => errors.push(error),
+            }
+        }
+        errors
+    }
+}
+
+impl Drop for XtestKeyGuard<'_> {
+    fn drop(&mut self) {
+        // Explicit cleanup reports errors to the caller. Drop is a final
+        // best-effort retry for connection failures during that cleanup.
+        let _ = self.cleanup();
     }
 }
 
@@ -388,7 +453,7 @@ fn key_is_pressed(keymap: &[u8; 32], keycode: u8) -> bool {
     keymap[byte] & (1 << bit) != 0
 }
 
-fn simulate_paste_xdotool() -> Result<(), String> {
+fn simulate_paste_xdotool() -> Result<(), PasteFailure> {
     let output = std::process::Command::new("xdotool")
         .args([
             "key",
@@ -398,15 +463,17 @@ fn simulate_paste_xdotool() -> Result<(), String> {
             "ctrl+v",
         ])
         .output()
-        .map_err(|error| format!("Failed to run xdotool: {}", error))?;
+        .map_err(|error| PasteFailure::Retryable(format!("Failed to start xdotool: {}", error)))?;
 
     if output.status.success() {
         Ok(())
     } else {
-        Err(format!(
+        // Once the process started, a failing exit status cannot prove that it
+        // emitted no input. Do not risk a duplicate through another backend.
+        Err(PasteFailure::Ambiguous(format!(
             "xdotool failed: {}",
             String::from_utf8_lossy(&output.stderr).trim()
-        ))
+        )))
     }
 }
 
@@ -515,21 +582,22 @@ impl Drop for UinputDevice {
     }
 }
 
-fn simulate_paste_uinput() -> Result<(), String> {
+fn simulate_paste_uinput() -> Result<(), PasteFailure> {
     let mut device = uinput_device_lock().lock();
 
     if let Some(existing) = device.as_mut() {
         match existing.send_ctrl_v() {
             Ok(()) => return Ok(()),
             Err(error) => {
-                eprintln!("[uinput] Existing device failed; recreating: {}", error);
+                eprintln!("[uinput] Existing device failed: {}", error);
                 *device = None;
+                return Err(PasteFailure::Ambiguous(error));
             }
         }
     }
 
-    let mut created = UinputDevice::create()?;
-    created.send_ctrl_v()?;
+    let mut created = UinputDevice::create().map_err(PasteFailure::Retryable)?;
+    created.send_ctrl_v().map_err(PasteFailure::Ambiguous)?;
     *device = Some(created);
     Ok(())
 }

--- a/src-tauri/src/input_simulator.rs
+++ b/src-tauri/src/input_simulator.rs
@@ -51,38 +51,68 @@ struct UinputDevice {
     file: File,
 }
 
-static UINPUT_DEVICE: OnceLock<Mutex<Option<UinputDevice>>> = OnceLock::new();
+/// Persistent XTest client. Connection setup, extension negotiation and
+/// keyboard-map discovery happen once rather than on every paste.
+struct XtestDevice {
+    connection: x11rb::rust_connection::RustConnection,
+    root_window: u32,
+    ctrl_keycode: u8,
+    v_keycode: u8,
+}
 
-/// Starts uinput discovery outside the paste hot path. If startup happens
-/// before permissions are granted, the first paste retries initialization.
+static UINPUT_DEVICE: OnceLock<Mutex<Option<UinputDevice>>> = OnceLock::new();
+static XTEST_DEVICE: OnceLock<Mutex<Option<XtestDevice>>> = OnceLock::new();
+
+/// Warms the active input backend outside the paste hot path. If startup
+/// initialization fails, the first paste retries it.
 pub fn init() {
-    if session::is_x11() {
+    let (thread_name, warmup): (&str, fn()) = if session::is_x11() {
+        ("xtest-paste-warmup", warm_up_xtest)
+    } else {
+        ("uinput-paste-warmup", warm_up_uinput)
+    };
+
+    if let Err(error) = std::thread::Builder::new()
+        .name(thread_name.to_string())
+        .spawn(warmup)
+    {
+        eprintln!("[SimulatePaste] Failed to start warmup thread: {}", error);
+    }
+}
+
+fn warm_up_xtest() {
+    let mut device = xtest_device_lock().lock();
+    if device.is_some() {
         return;
     }
 
-    if let Err(error) = std::thread::Builder::new()
-        .name("uinput-paste-warmup".to_string())
-        .spawn(|| {
-            let mut device = uinput_device_lock().lock();
-            if device.is_some() {
-                return;
-            }
+    match XtestDevice::create() {
+        Ok(created) => {
+            *device = Some(created);
+            eprintln!("[XTest] Persistent X11 input client is ready");
+        }
+        Err(error) => eprintln!(
+            "[XTest] Startup warmup failed; first paste will retry: {}",
+            error
+        ),
+    }
+}
 
-            match UinputDevice::create() {
-                Ok(created) => {
-                    *device = Some(created);
-                    eprintln!("[uinput] Virtual keyboard warmed up at startup");
-                }
-                Err(error) => {
-                    eprintln!(
-                        "[uinput] Startup warmup failed; first paste will retry: {}",
-                        error
-                    );
-                }
-            }
-        })
-    {
-        eprintln!("[uinput] Failed to start warmup thread: {}", error);
+fn warm_up_uinput() {
+    let mut device = uinput_device_lock().lock();
+    if device.is_some() {
+        return;
+    }
+
+    match UinputDevice::create() {
+        Ok(created) => {
+            *device = Some(created);
+            eprintln!("[uinput] Virtual keyboard warmed up at startup");
+        }
+        Err(error) => eprintln!(
+            "[uinput] Startup warmup failed; first paste will retry: {}",
+            error
+        ),
     }
 }
 
@@ -135,100 +165,134 @@ fn fake_key<C: x11rb::connection::Connection + x11rb::protocol::xtest::Connectio
 }
 
 fn simulate_paste_xtest() -> Result<(), String> {
-    use x11rb::connection::Connection;
-    use x11rb::protocol::xtest::ConnectionExt as XtestConnectionExt;
-
-    let (conn, screen_num) =
-        x11rb::connect(None).map_err(|error| format!("X11 connect failed: {}", error))?;
-    let root_window = conn
-        .setup()
-        .roots
-        .get(screen_num)
-        .ok_or("X11 screen not found")?
-        .root;
-
-    conn.xtest_get_version(2, 1)
-        .map_err(|error| format!("XTest version query failed: {}", error))?
-        .reply()
-        .map_err(|error| format!("XTest version query failed: {}", error))?;
-
-    let (ctrl_keycode, v_keycode) = resolve_paste_keycodes(&conn)?;
-    let mut ctrl_down = false;
-    let mut v_down = false;
-
-    let operation = (|| {
-        fake_key(
-            &conn,
-            X11_KEY_PRESS,
-            ctrl_keycode,
-            root_window,
-            "Failed to press Ctrl",
-        )?;
-        ctrl_down = true;
-        wait_for_x11_key_state(&conn, ctrl_keycode, true)?;
-
-        fake_key(
-            &conn,
-            X11_KEY_PRESS,
-            v_keycode,
-            root_window,
-            "Failed to press V",
-        )?;
-        v_down = true;
-        wait_for_x11_key_state(&conn, v_keycode, true)?;
-
-        fake_key(
-            &conn,
-            X11_KEY_RELEASE,
-            v_keycode,
-            root_window,
-            "Failed to release V",
-        )?;
-        v_down = false;
-
-        fake_key(
-            &conn,
-            X11_KEY_RELEASE,
-            ctrl_keycode,
-            root_window,
-            "Failed to release Ctrl",
-        )?;
-        ctrl_down = false;
-
-        wait_for_x11_key_state(&conn, v_keycode, false)?;
-        wait_for_x11_key_state(&conn, ctrl_keycode, false)
-    })();
-
-    // Never leave a synthetic modifier held if a round trip fails midway.
-    let mut cleanup_errors = Vec::new();
-    if v_down {
-        if let Err(error) = fake_key(
-            &conn,
-            X11_KEY_RELEASE,
-            v_keycode,
-            root_window,
-            "Cleanup failed to release V",
-        ) {
-            cleanup_errors.push(error);
-        }
-    }
-    if ctrl_down {
-        if let Err(error) = fake_key(
-            &conn,
-            X11_KEY_RELEASE,
-            ctrl_keycode,
-            root_window,
-            "Cleanup failed to release Ctrl",
-        ) {
-            cleanup_errors.push(error);
-        }
+    let mut device = xtest_device_lock().lock();
+    if device.is_none() {
+        *device = Some(XtestDevice::create()?);
     }
 
-    match (operation, cleanup_errors.is_empty()) {
-        (Ok(()), true) => Ok(()),
-        (Ok(()), false) => Err(cleanup_errors.join("; ")),
-        (Err(error), true) => Err(error),
-        (Err(error), false) => Err(format!("{}; {}", error, cleanup_errors.join("; "))),
+    let result = device
+        .as_mut()
+        .expect("XTest device was initialized")
+        .send_ctrl_v();
+    if result.is_err() {
+        // Reconnect on the next attempt if the X server connection went away.
+        *device = None;
+    }
+    result
+}
+
+fn xtest_device_lock() -> &'static Mutex<Option<XtestDevice>> {
+    XTEST_DEVICE.get_or_init(|| Mutex::new(None))
+}
+
+impl XtestDevice {
+    fn create() -> Result<Self, String> {
+        use x11rb::connection::Connection;
+        use x11rb::protocol::xtest::ConnectionExt as XtestConnectionExt;
+
+        let (connection, screen_num) =
+            x11rb::connect(None).map_err(|error| format!("X11 connect failed: {}", error))?;
+        let root_window = connection
+            .setup()
+            .roots
+            .get(screen_num)
+            .ok_or("X11 screen not found")?
+            .root;
+
+        connection
+            .xtest_get_version(2, 1)
+            .map_err(|error| format!("XTest version query failed: {}", error))?
+            .reply()
+            .map_err(|error| format!("XTest version query failed: {}", error))?;
+
+        let (ctrl_keycode, v_keycode) = resolve_paste_keycodes(&connection)?;
+
+        Ok(Self {
+            connection,
+            root_window,
+            ctrl_keycode,
+            v_keycode,
+        })
+    }
+
+    fn send_ctrl_v(&mut self) -> Result<(), String> {
+        let mut ctrl_down = false;
+        let mut v_down = false;
+
+        let operation = (|| {
+            fake_key(
+                &self.connection,
+                X11_KEY_PRESS,
+                self.ctrl_keycode,
+                self.root_window,
+                "Failed to press Ctrl",
+            )?;
+            ctrl_down = true;
+            wait_for_x11_key_state(&self.connection, self.ctrl_keycode, true)?;
+
+            fake_key(
+                &self.connection,
+                X11_KEY_PRESS,
+                self.v_keycode,
+                self.root_window,
+                "Failed to press V",
+            )?;
+            v_down = true;
+            wait_for_x11_key_state(&self.connection, self.v_keycode, true)?;
+
+            fake_key(
+                &self.connection,
+                X11_KEY_RELEASE,
+                self.v_keycode,
+                self.root_window,
+                "Failed to release V",
+            )?;
+            v_down = false;
+
+            fake_key(
+                &self.connection,
+                X11_KEY_RELEASE,
+                self.ctrl_keycode,
+                self.root_window,
+                "Failed to release Ctrl",
+            )?;
+            ctrl_down = false;
+
+            wait_for_x11_key_state(&self.connection, self.v_keycode, false)?;
+            wait_for_x11_key_state(&self.connection, self.ctrl_keycode, false)
+        })();
+
+        // Never leave a synthetic modifier held if a round trip fails midway.
+        let mut cleanup_errors = Vec::new();
+        if v_down {
+            if let Err(error) = fake_key(
+                &self.connection,
+                X11_KEY_RELEASE,
+                self.v_keycode,
+                self.root_window,
+                "Cleanup failed to release V",
+            ) {
+                cleanup_errors.push(error);
+            }
+        }
+        if ctrl_down {
+            if let Err(error) = fake_key(
+                &self.connection,
+                X11_KEY_RELEASE,
+                self.ctrl_keycode,
+                self.root_window,
+                "Cleanup failed to release Ctrl",
+            ) {
+                cleanup_errors.push(error);
+            }
+        }
+
+        match (operation, cleanup_errors.is_empty()) {
+            (Ok(()), true) => Ok(()),
+            (Ok(()), false) => Err(cleanup_errors.join("; ")),
+            (Err(error), true) => Err(error),
+            (Err(error), false) => Err(format!("{}; {}", error, cleanup_errors.join("; "))),
+        }
     }
 }
 

--- a/src-tauri/src/input_simulator.rs
+++ b/src-tauri/src/input_simulator.rs
@@ -139,9 +139,9 @@ pub fn simulate_paste_keystroke() -> Result<(), String> {
     // XTest uses one native X11 connection and verifies that Ctrl is down
     // before V. xdotool is retained only as a compatibility fallback.
     const X11_STRATEGIES: &[PasteStrategy] = &[
-        ("XTest", simulate_paste_xtest),
-        ("xdotool", simulate_paste_xdotool),
         ("uinput", simulate_paste_uinput),
+        ("xdotool", simulate_paste_xdotool),
+        ("XTest", simulate_paste_xtest),
     ];
     const NON_X11_STRATEGIES: &[PasteStrategy] = &[("uinput", simulate_paste_uinput)];
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -876,6 +876,7 @@ fn main() {
             // Starting it earlier would hotplug a temporary keyboard every
             // time the desktop launches the shortcut command.
             win11_clipboard_history_lib::input_simulator::init();
+            win11_clipboard_history_lib::paste_sync::init();
 
             // FIRST THING: If started in background mode, immediately hide the main window
             // This runs before anything else to prevent the window from appearing

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -316,8 +316,14 @@ impl PasteHelper {
     /// Restores focus to the previous window and waits for it to settle.
     /// This ensures keystrokes are sent to the correct application.
     async fn prepare_target_window(app: &AppHandle) -> Result<(), String> {
+        // `hide()` is dispatched to Tauri's event loop when commands run off
+        // the main thread. Observe its completion before asking X11 to restore
+        // focus, otherwise a pending UnmapNotify can steal focus back after an
+        // apparently stable X11 sample.
+        Self::wait_for_popup_to_release_focus(app).await?;
+
         if is_wayland() {
-            return Self::wait_for_wayland_popup_to_release_focus(app).await;
+            return Ok(());
         }
 
         match restore_focused_window() {
@@ -335,10 +341,10 @@ impl PasteHelper {
         Ok(())
     }
 
-    /// Wayland does not allow an application to force focus onto an arbitrary
-    /// client. Hiding our popup lets the compositor restore focus naturally;
-    /// poll Tauri's real visibility/focus state rather than sleeping blindly.
-    async fn wait_for_wayland_popup_to_release_focus(app: &AppHandle) -> Result<(), String> {
+    /// Waits for Tauri's asynchronous hide/focus events to settle. On Wayland
+    /// this is the strongest target-readiness signal available; on X11 it is
+    /// the prerequisite for explicitly restoring the previously focused app.
+    async fn wait_for_popup_to_release_focus(app: &AppHandle) -> Result<(), String> {
         let window = app
             .get_webview_window("main")
             .ok_or("Main window is not available")?;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -40,6 +40,10 @@ pub struct AppState {
     emoji_manager: Arc<Mutex<EmojiManager>>,
     config_manager: Arc<Mutex<ConfigManager>>,
     is_mouse_inside: Arc<AtomicBool>,
+    /// Serializes the complete clipboard/focus/input transaction. Locking only
+    /// the virtual device still allows two commands to swap clipboard content
+    /// before either chord is emitted.
+    paste_gate: tokio::sync::Mutex<()>,
 }
 
 // --- Commands ---
@@ -149,6 +153,8 @@ fn is_theme_listener_active() -> bool {
 
 #[tauri::command]
 async fn paste_item(app: AppHandle, state: State<'_, AppState>, id: String) -> Result<(), String> {
+    let _paste_guard = state.paste_gate.lock().await;
+
     // 1. Get Item (Scope lock tightly)
     let item = {
         let manager = state.clipboard_manager.lock();
@@ -159,7 +165,7 @@ async fn paste_item(app: AppHandle, state: State<'_, AppState>, id: String) -> R
         Some(item) => {
             // 2. Prepare Environment (Hide Window -> Restore Focus)
             WindowController::hide(&app);
-            PasteHelper::prepare_target_window().await?;
+            PasteHelper::prepare_target_window(&app).await?;
 
             // 3. Perform Paste
             let mut manager = state.clipboard_manager.lock();
@@ -191,6 +197,8 @@ async fn paste_text(
     text: String,
     item_type: Option<String>,
 ) -> Result<(), String> {
+    let _paste_guard = state.paste_gate.lock().await;
+
     // 0. Record usage if applicable
     if let Some(t) = item_type.as_deref() {
         if t == "emoji" {
@@ -200,7 +208,7 @@ async fn paste_text(
 
     // 1. Prepare Environment
     WindowController::hide(&app);
-    PasteHelper::prepare_target_window().await?;
+    PasteHelper::prepare_target_window(&app).await?;
 
     // 2. Set Clipboard & Mark
     {
@@ -221,6 +229,8 @@ async fn paste_gif_from_url(
     state: State<'_, AppState>,
     url: String,
 ) -> Result<(), String> {
+    let _paste_guard = state.paste_gate.lock().await;
+
     // 1. Download (Blocking) - Window stays open to show loading if UI supports it
     let url_clone = url.clone();
     let file_uri = tokio::task::spawn_blocking(move || {
@@ -241,7 +251,7 @@ async fn paste_gif_from_url(
 
     // 3. Prepare Environment & Paste
     WindowController::hide(&app);
-    PasteHelper::prepare_target_window().await?;
+    PasteHelper::prepare_target_window(&app).await?;
 
     // The clipboard is already set by paste_gif_to_clipboard_with_uri, we just need to paste
     simulate_paste_keystroke().map_err(|e| e.to_string())?;
@@ -250,9 +260,10 @@ async fn paste_gif_from_url(
 }
 
 #[tauri::command]
-async fn finish_paste(app: AppHandle) -> Result<(), String> {
+async fn finish_paste(app: AppHandle, state: State<'_, AppState>) -> Result<(), String> {
+    let _paste_guard = state.paste_gate.lock().await;
     WindowController::hide(&app);
-    PasteHelper::prepare_target_window().await?;
+    PasteHelper::prepare_target_window(&app).await?;
     simulate_paste_keystroke().map_err(|e| e.to_string())?;
     Ok(())
 }
@@ -298,25 +309,65 @@ async fn finish_setup(app: AppHandle) -> Result<(), String> {
 struct PasteHelper;
 
 impl PasteHelper {
+    const TARGET_READY_TIMEOUT: Duration = Duration::from_millis(750);
+    const TARGET_READY_POLL_INTERVAL: Duration = Duration::from_millis(2);
+    const TARGET_STABLE_SAMPLES: u8 = 2;
+
     /// Restores focus to the previous window and waits for it to settle.
     /// This ensures keystrokes are sent to the correct application.
-    async fn prepare_target_window() -> Result<(), String> {
+    async fn prepare_target_window(app: &AppHandle) -> Result<(), String> {
+        if is_wayland() {
+            return Self::wait_for_wayland_popup_to_release_focus(app).await;
+        }
+
         match restore_focused_window() {
             Ok(true) => {
                 // Focus was *verified* on the target window by the poller;
                 // no extra settle time is needed.
             }
             Ok(false) => {
-                // Focus restore was requested but could not be verified —
-                // keep the original conservative settle delay.
-                tokio::time::sleep(Duration::from_millis(100)).await;
+                return Err("Target window did not acquire stable focus".to_string());
             }
             Err(e) => {
-                eprintln!("[PasteHelper] Warning: Focus restoration failed: {}", e);
-                tokio::time::sleep(Duration::from_millis(100)).await;
+                return Err(format!("Focus restoration failed: {}", e));
             }
         }
         Ok(())
+    }
+
+    /// Wayland does not allow an application to force focus onto an arbitrary
+    /// client. Hiding our popup lets the compositor restore focus naturally;
+    /// poll Tauri's real visibility/focus state rather than sleeping blindly.
+    async fn wait_for_wayland_popup_to_release_focus(app: &AppHandle) -> Result<(), String> {
+        let window = app
+            .get_webview_window("main")
+            .ok_or("Main window is not available")?;
+        let start = std::time::Instant::now();
+        let mut stable_samples = 0;
+
+        loop {
+            let last_state = match (window.is_visible(), window.is_focused()) {
+                (Ok(false), Ok(false)) => {
+                    stable_samples += 1;
+                    if stable_samples >= Self::TARGET_STABLE_SAMPLES {
+                        return Ok(());
+                    }
+                    "visible=false, focused=false (settling)".to_string()
+                }
+                (visible, focused) => {
+                    stable_samples = 0;
+                    format!("visible={:?}, focused={:?}", visible, focused)
+                }
+            };
+
+            if start.elapsed() >= Self::TARGET_READY_TIMEOUT {
+                return Err(format!(
+                    "Timed out waiting for the clipboard popup to release focus ({})",
+                    last_state
+                ));
+            }
+            tokio::time::sleep(Self::TARGET_READY_POLL_INTERVAL).await;
+        }
     }
 }
 
@@ -802,6 +853,7 @@ fn main() {
             emoji_manager: emoji_manager.clone(),
             config_manager: config_manager.clone(),
             is_mouse_inside: is_mouse_inside.clone(),
+            paste_gate: tokio::sync::Mutex::new(()),
         })
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::Destroyed = event {
@@ -818,6 +870,12 @@ fn main() {
         })
         .setup(move |app| {
             let app_handle = app.handle().clone();
+
+            // This runs only for the primary instance, after the
+            // single-instance plugin has rejected shortcut helper processes.
+            // Starting it earlier would hotplug a temporary keyboard every
+            // time the desktop launches the shortcut command.
+            win11_clipboard_history_lib::input_simulator::init();
 
             // FIRST THING: If started in background mode, immediately hide the main window
             // This runs before anything else to prevent the window from appearing

--- a/src-tauri/src/paste_sync.rs
+++ b/src-tauri/src/paste_sync.rs
@@ -1,19 +1,13 @@
 //! Paste Synchronization Module
 //!
-//! Replaces blind hardcoded sleeps in the paste pipeline with *verified*
-//! condition polling. Each settle function polls the real X11 state at a
-//! short interval and returns as soon as the condition is confirmed, using
-//! the previous hardcoded sleep duration as a worst-case budget.
+//! Adaptive X11 barriers for the paste pipeline. Each function polls an
+//! observable server condition and returns as soon as it is confirmed. The
+//! caller chooses a timeout as a failure ceiling, so constrained systems get
+//! more time without imposing that delay on fast systems.
 //!
-//! Guarantee: a settle call NEVER takes longer than the old fixed sleep
-//! (poll time and fallback sleep share the same budget), and never returns
-//! earlier without the condition being confirmed. On a slow system the
-//! behavior is identical to before; on a normal system each step completes
-//! in single-digit milliseconds.
-//!
-//! IMPORTANT: This module does NOT change any input simulation strategy or
-//! key-event parameter. It only converts "sleep and hope" into
-//! "poll until confirmed".
+//! These helpers return whether the condition was actually confirmed. Paste
+//! code must treat `false` as a failed precondition rather than continuing
+//! with an unverified input sequence.
 
 use crate::session;
 use std::thread;
@@ -22,6 +16,11 @@ use x11rb::protocol::xproto::ConnectionExt;
 
 /// Polling interval for all waiters. Cheap X11 round-trips (~0.1ms each).
 const POLL_INTERVAL: Duration = Duration::from_millis(3);
+
+/// A single matching focus sample can occur before a pending WM transition
+/// (such as our popup's UnmapNotify) is processed. Requiring stability closes
+/// that transient-match race at a cost of one short poll on fast systems.
+const FOCUS_STABLE_SAMPLES: u8 = 2;
 
 /// Returns the current owner window of the CLIPBOARD selection,
 /// or `None` when it cannot be determined (non-X11, connection failure).
@@ -44,20 +43,30 @@ pub fn clipboard_owner() -> Option<u32> {
 /// Wait (at most `budget`) for the X11 input focus to land on
 /// `target_window`. Returns `true` if the focus was confirmed early.
 ///
-/// Replaces the fixed FOCUS_RESTORE_DELAY sleep: instead of assuming the
+/// Replaces a fixed focus sleep: instead of assuming the
 /// window manager needs N ms to process `set_input_focus`, we watch the
 /// actual focus and return the moment it settles. When verification is
-/// impossible (non-X11, connection failure), sleeps the full budget —
-/// identical to the previous behavior.
+/// impossible (non-X11, connection failure), sleeps the full budget.
 pub fn settle_focus(target_window: u32, budget: Duration) -> bool {
     let start = Instant::now();
+    let mut stable_samples = 0;
     let confirmed = poll_until(budget, || {
         if !session::is_x11() || target_window == 0 {
             return PollState::Unverifiable;
         }
         match focused_window() {
-            Some(focus) if focus == target_window => PollState::Confirmed,
-            Some(_) => PollState::Pending,
+            Some(focus) if focus == target_window => {
+                stable_samples += 1;
+                if stable_samples >= FOCUS_STABLE_SAMPLES {
+                    PollState::Confirmed
+                } else {
+                    PollState::Pending
+                }
+            }
+            Some(_) => {
+                stable_samples = 0;
+                PollState::Pending
+            }
             None => PollState::Unverifiable,
         }
     });

--- a/src-tauri/src/paste_sync.rs
+++ b/src-tauri/src/paste_sync.rs
@@ -1,165 +1,185 @@
-//! Paste Synchronization Module
+//! Paste synchronization barriers for X11.
 //!
-//! Adaptive X11 barriers for the paste pipeline. Each function polls an
-//! observable server condition and returns as soon as it is confirmed. The
-//! caller chooses a timeout as a failure ceiling, so constrained systems get
-//! more time without imposing that delay on fast systems.
-//!
-//! These helpers return whether the condition was actually confirmed. Paste
-//! code must treat `false` as a failed precondition rather than continuing
-//! with an unverified input sequence.
+//! A single cached X11 connection is used for focus and clipboard checks.
+//! Besides avoiding connection setup on every paste, keeping the atom cache
+//! and polling on one connection makes the hot path both cheaper and easier
+//! to reason about.
 
 use crate::session;
+use parking_lot::Mutex;
+use std::sync::OnceLock;
 use std::thread;
 use std::time::{Duration, Instant};
-use x11rb::protocol::xproto::ConnectionExt;
+use x11rb::connection::Connection;
+use x11rb::protocol::xproto::{Atom, ConnectionExt, InputFocus};
+use x11rb::rust_connection::RustConnection;
 
-/// Polling interval for all waiters. Cheap X11 round-trips (~0.1ms each).
+/// Polling interval for all waiters. X11 round trips are local and cheap.
 const POLL_INTERVAL: Duration = Duration::from_millis(3);
 
-/// A single matching focus sample can occur before a pending WM transition
-/// (such as our popup's UnmapNotify) is processed. Requiring stability closes
-/// that transient-match race at a cost of one short poll on fast systems.
+/// One matching focus sample can precede a pending WM transition. Requiring
+/// two consecutive samples closes that transient-match race.
 const FOCUS_STABLE_SAMPLES: u8 = 2;
 
-/// Returns the current owner window of the CLIPBOARD selection,
-/// or `None` when it cannot be determined (non-X11, connection failure).
-/// `Some(0)` (x11rb::NONE) means "no owner".
-pub fn clipboard_owner() -> Option<u32> {
+struct X11Context {
+    connection: RustConnection,
+    clipboard_atom: Atom,
+}
+
+impl X11Context {
+    fn connect() -> Result<Self, String> {
+        let (connection, _) =
+            x11rb::connect(None).map_err(|error| format!("X11 connection failed: {}", error))?;
+        let clipboard_atom = connection
+            .intern_atom(false, b"CLIPBOARD")
+            .map_err(|error| format!("Failed to intern CLIPBOARD: {}", error))?
+            .reply()
+            .map_err(|error| format!("Failed to intern CLIPBOARD: {}", error))?
+            .atom;
+
+        Ok(Self {
+            connection,
+            clipboard_atom,
+        })
+    }
+
+    fn clipboard_owner(&self) -> Result<u32, String> {
+        self.connection
+            .get_selection_owner(self.clipboard_atom)
+            .map_err(|error| format!("Failed to query clipboard owner: {}", error))?
+            .reply()
+            .map_err(|error| format!("Failed to query clipboard owner: {}", error))
+            .map(|reply| reply.owner)
+    }
+
+    fn focused_window(&self) -> Result<u32, String> {
+        self.connection
+            .get_input_focus()
+            .map_err(|error| format!("Failed to query X11 focus: {}", error))?
+            .reply()
+            .map_err(|error| format!("Failed to query X11 focus: {}", error))
+            .map(|reply| reply.focus)
+    }
+}
+
+static X11_CONTEXT: OnceLock<Mutex<Option<X11Context>>> = OnceLock::new();
+
+fn x11_context() -> &'static Mutex<Option<X11Context>> {
+    X11_CONTEXT.get_or_init(|| Mutex::new(None))
+}
+
+fn with_x11_context<T>(
+    operation: impl FnOnce(&mut X11Context) -> Result<T, String>,
+) -> Result<T, String> {
     if !session::is_x11() {
-        return None;
+        return Err("X11 synchronization requested outside an X11 session".to_string());
     }
-    let (conn, _) = x11rb::connect(None).ok()?;
-    let atom = conn
-        .intern_atom(false, b"CLIPBOARD")
-        .ok()?
-        .reply()
-        .ok()?
-        .atom;
-    let owner = conn.get_selection_owner(atom).ok()?.reply().ok()?.owner;
-    Some(owner)
+
+    let mut slot = x11_context().lock();
+    if slot.is_none() {
+        *slot = Some(X11Context::connect()?);
+    }
+
+    let result = operation(slot.as_mut().expect("X11 context was initialized"));
+    if result.is_err() {
+        // A broken server connection should not poison every later paste.
+        // The next operation reconnects lazily.
+        *slot = None;
+    }
+    result
 }
 
-/// Wait (at most `budget`) for the X11 input focus to land on
-/// `target_window`. Returns `true` if the focus was confirmed early.
-///
-/// Replaces a fixed focus sleep: instead of assuming the
-/// window manager needs N ms to process `set_input_focus`, we watch the
-/// actual focus and return the moment it settles. When verification is
-/// impossible (non-X11, connection failure), sleeps the full budget.
-pub fn settle_focus(target_window: u32, budget: Duration) -> bool {
-    let start = Instant::now();
-    let mut stable_samples = 0;
-    let confirmed = poll_until(budget, || {
-        if !session::is_x11() || target_window == 0 {
-            return PollState::Unverifiable;
-        }
-        match focused_window() {
-            Some(focus) if focus == target_window => {
+/// Warms the cached X11 synchronization connection outside the paste path.
+pub fn init() {
+    if !session::is_x11() {
+        return;
+    }
+
+    if let Err(error) = thread::Builder::new()
+        .name("x11-paste-sync-warmup".to_string())
+        .spawn(|| match with_x11_context(|_| Ok(())) {
+            Ok(()) => eprintln!("[PasteSync] X11 synchronization connection is ready"),
+            Err(error) => eprintln!(
+                "[PasteSync] X11 warmup failed; first paste will retry: {}",
+                error
+            ),
+        })
+    {
+        eprintln!("[PasteSync] Failed to start warmup thread: {}", error);
+    }
+}
+
+/// Returns the current owner window of the CLIPBOARD selection.
+/// `Some(0)` (`x11rb::NONE`) means that the selection has no owner.
+pub fn clipboard_owner() -> Option<u32> {
+    with_x11_context(|context| context.clipboard_owner()).ok()
+}
+
+/// Returns the window that currently has X11 input focus.
+pub fn focused_window() -> Option<u32> {
+    with_x11_context(|context| context.focused_window()).ok()
+}
+
+/// Requests focus for `target_window` and waits until it is observed in two
+/// consecutive samples. The request and verification share one connection,
+/// so request ordering is guaranteed without a fixed settle delay.
+pub fn restore_and_settle_focus(target_window: u32, timeout: Duration) -> Result<bool, String> {
+    if target_window == 0 {
+        return Err("Cannot restore focus to X11 window 0".to_string());
+    }
+
+    with_x11_context(|context| {
+        context
+            .connection
+            .set_input_focus(InputFocus::PARENT, target_window, x11rb::CURRENT_TIME)
+            .map_err(|error| format!("Set focus failed: {}", error))?;
+        context
+            .connection
+            .flush()
+            .map_err(|error| format!("X11 focus flush failed: {}", error))?;
+
+        let mut stable_samples = 0;
+        poll_until(timeout, || {
+            if context.focused_window()? == target_window {
                 stable_samples += 1;
-                if stable_samples >= FOCUS_STABLE_SAMPLES {
-                    PollState::Confirmed
-                } else {
-                    PollState::Pending
-                }
-            }
-            Some(_) => {
+                Ok(stable_samples >= FOCUS_STABLE_SAMPLES)
+            } else {
                 stable_samples = 0;
-                PollState::Pending
+                Ok(false)
             }
-            None => PollState::Unverifiable,
-        }
-    });
-
-    if !confirmed {
-        sleep_remaining(start, budget);
-    }
-    confirmed
+        })
+    })
 }
 
-/// Wait (at most `budget`) for the CLIPBOARD selection owner to *change*
-/// from `owner_before` (to a non-NONE owner). Returns `true` if the handoff
-/// was confirmed early.
-///
-/// Replaces the fixed "clipboard settle" sleep after spawning xclip/wl-copy:
-/// the instant the X server reports the new selection owner, any target app
-/// will read the new content — there is nothing further to wait for.
-/// Checking for a *change* (not just presence) avoids a false positive when
-/// the previous owner is still holding the selection.
-pub fn settle_clipboard_handoff(owner_before: Option<u32>, budget: Duration) -> bool {
-    let start = Instant::now();
-    let confirmed = poll_until(budget, || {
-        let before = match owner_before {
-            Some(owner) => owner,
-            None => return PollState::Unverifiable,
-        };
-        match clipboard_owner() {
-            Some(owner) if owner != x11rb::NONE && owner != before => PollState::Confirmed,
-            Some(_) => PollState::Pending,
-            None => PollState::Unverifiable,
-        }
-    });
+/// Waits for the CLIPBOARD owner to change to a non-empty owner.
+pub fn settle_clipboard_handoff(owner_before: Option<u32>, timeout: Duration) -> bool {
+    let Some(owner_before) = owner_before else {
+        // The caller can immediately use its fallback instead of paying the
+        // full timeout for a condition that cannot be verified.
+        return false;
+    };
 
-    if !confirmed {
-        sleep_remaining(start, budget);
-    }
-    confirmed
+    with_x11_context(|context| {
+        poll_until(timeout, || {
+            let owner = context.clipboard_owner()?;
+            Ok(owner != x11rb::NONE && owner != owner_before)
+        })
+    })
+    .unwrap_or(false)
 }
 
-/// Wait (at most `budget`) for the CLIPBOARD selection to have *some* owner.
-/// Weaker check than [`settle_clipboard_handoff`], used as a final settle
-/// confirmation right before the paste keystroke, after the write has
-/// already been verified upstream.
-pub fn settle_clipboard_owned(budget: Duration) -> bool {
-    let start = Instant::now();
-    let confirmed = poll_until(budget, || match clipboard_owner() {
-        Some(owner) if owner != x11rb::NONE => PollState::Confirmed,
-        Some(_) => PollState::Pending,
-        None => PollState::Unverifiable,
-    });
-
-    if !confirmed {
-        sleep_remaining(start, budget);
-    }
-    confirmed
-}
-
-// --- internals ---
-
-enum PollState {
-    Confirmed,
-    Pending,
-    Unverifiable,
-}
-
-/// Polls `check` every POLL_INTERVAL until it confirms, becomes
-/// unverifiable, or `budget` elapses. Returns `true` only on confirmation.
-fn poll_until(budget: Duration, mut check: impl FnMut() -> PollState) -> bool {
-    let deadline = Instant::now() + budget;
+fn poll_until(
+    timeout: Duration,
+    mut check: impl FnMut() -> Result<bool, String>,
+) -> Result<bool, String> {
+    let deadline = Instant::now() + timeout;
     loop {
-        match check() {
-            PollState::Confirmed => return true,
-            PollState::Unverifiable => return false,
-            PollState::Pending => {}
+        if check()? {
+            return Ok(true);
         }
         if Instant::now() >= deadline {
-            return false;
+            return Ok(false);
         }
         thread::sleep(POLL_INTERVAL);
     }
-}
-
-/// Sleeps whatever is left of `budget`, so an unconfirmed settle takes
-/// exactly as long as the old fixed sleep did — never longer.
-fn sleep_remaining(start: Instant, budget: Duration) {
-    let remaining = budget.saturating_sub(start.elapsed());
-    if !remaining.is_zero() {
-        thread::sleep(remaining);
-    }
-}
-
-fn focused_window() -> Option<u32> {
-    let (conn, _) = x11rb::connect(None).ok()?;
-    let reply = conn.get_input_focus().ok()?.reply().ok()?;
-    Some(reply.focus)
 }


### PR DESCRIPTION
## 📝 Description

<!-- Describe your changes in detail -->

## 🔗 Related Issue

<!-- Link to the issue this PR addresses (if any) -->
- #

## 🧪 Type of Change

<!-- Mark the appropriate option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Chore (build process, dependencies, etc.)

## 📸 Screenshots (if applicable)

<!-- Add screenshots to show UI changes -->

## ✅ Checklist

<!-- Mark completed items with an 'x' -->

- [ ] My code follows the project's code style
- [ ] I have run `make lint` and `make format`
- [ ] I have tested my changes locally
- [ ] I have added/updated documentation as needed
- [ ] My changes don't introduce new warnings
- [ ] I have tested on both X11 and Wayland (if applicable)

## 🖥️ Testing Environment

- **OS**: 
- **Desktop Environment**: 
- **Display Server**: [X11 / Wayland]

## 📋 Additional Notes

<!-- Add any additional information for reviewers -->

## Summary by Sourcery

Improve reliability and synchronization of the paste pipeline across X11 and Wayland by making focus, clipboard ownership, and virtual input device readiness adaptive and explicitly verified before emitting Ctrl+V.

New Features:
- Introduce a persistent uinput-based virtual keyboard that is initialized once at startup and reused for paste operations.
- Add a global async paste gate in application state to serialize clipboard, focus, and input operations across paste commands.
- Provide Wayland-specific focus handling that waits for the clipboard popup to fully release visibility and focus before pasting.

Bug Fixes:
- Ensure Ctrl+V is emitted as a single coherent sequence to prevent stray literal `v` characters under compositor/device load.
- Require confirmed clipboard ownership and selection handoff before triggering paste, avoiding pastes against stale or unacquired clipboard content.
- Prevent synthetic modifiers from remaining stuck on X11 by cleaning up key state if XTest sequences fail mid-operation.

Enhancements:
- Make X11 paste via XTest dynamically resolve keycodes from the active keymap and verify key press/release state via round trips instead of fixed delays.
- Replace hardcoded sleeps with timeout-based polling for X11 focus, clipboard ownership, and helper readiness, so fast systems are not penalized by worst-case delays.
- Refine wl-copy and xclip integration to treat helper completion or timeouts as explicit readiness signals and propagate detailed error messages when they fail.
- Tighten focus restoration semantics to require a stable, confirmed target focus window rather than best-effort delays.