### PR TITLE
Feat/clear search on close

### DIFF
--- a/src-tauri/src/clipboard_manager.rs
+++ b/src-tauri/src/clipboard_manager.rs
@@ -62,6 +62,60 @@ fn get_system_clipboard() -> Result<Clipboard, String> {
     Clipboard::new().map_err(|e| e.to_string())
 }
 
+// --- Free-function clipboard access ---
+//
+// The clipboard watcher must read the system clipboard WITHOUT holding the
+// manager lock: arboard/X11 clipboard reads can block for a long time if the
+// clipboard owner is slow, and holding the lock across such a read would
+// freeze every UI command (get_history, toggle_pin, ...) that needs it.
+
+/// Read plain text from the system clipboard. May block on some platforms.
+pub fn read_clipboard_text() -> Result<String, arboard::Error> {
+    Clipboard::new()?.get_text()
+}
+
+/// Try to get HTML content from clipboard. Returns None if not available.
+pub fn read_clipboard_html() -> Option<String> {
+    let mut clipboard = get_system_clipboard().ok()?;
+    clipboard.get().html().ok()
+}
+
+/// Read an image from the system clipboard, returning raw RGBA bytes + hash.
+/// May block on some platforms.
+pub fn read_clipboard_image() -> Result<Option<(ImageData<'static>, u64)>, arboard::Error> {
+    let mut clipboard = Clipboard::new()?;
+
+    match clipboard.get_image() {
+        Ok(image) => {
+            let hash = calculate_hash(&image.bytes);
+            let owned = ImageData {
+                width: image.width,
+                height: image.height,
+                bytes: image.bytes.into_owned().into(),
+            };
+            Ok(Some((owned, hash)))
+        }
+        Err(arboard::Error::ContentNotAvailable) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Encode raw RGBA image bytes to a base64 PNG string.
+/// CPU heavy for large images, so callers should avoid holding locks.
+pub fn encode_image_to_base64(image_data: &ImageData<'_>) -> Option<String> {
+    let img = DynamicImage::ImageRgba8(
+        image::RgbaImage::from_raw(
+            image_data.width as u32,
+            image_data.height as u32,
+            image_data.bytes.to_vec(),
+        )?, // Returns None if dimensions don't match bytes
+    );
+
+    let mut buffer = Cursor::new(Vec::new());
+    img.write_to(&mut buffer, ImageFormat::Png).ok()?;
+    Some(BASE64.encode(buffer.get_ref()))
+}
+
 // --- Data Structures ---
 
 /// Content type for clipboard items
@@ -157,6 +211,27 @@ impl ClipboardItem {
             .split('#')
             .nth(1)
             .and_then(|h| h.parse::<u64>().ok())
+    }
+
+    /// Returns a copy of this item with heavy image data removed.
+    /// Used for list/history payloads so image base64 is not shipped over
+    /// IPC on every open/sync. Full content is fetched on demand via
+    /// `get_item_content`.
+    pub fn lightweight(&self) -> Self {
+        let content = match &self.content {
+            ClipboardContent::Image { width, height, .. } => ClipboardContent::Image {
+                base64: String::new(),
+                width: *width,
+                height: *height,
+            },
+            other => other.clone(),
+        };
+        // The remaining fields (id, timestamp, pinned, preview) are small, so
+        // cloning the rest of the struct is cheap; only `content` is heavy.
+        Self {
+            content,
+            ..self.clone()
+        }
     }
 }
 
@@ -299,35 +374,18 @@ impl ClipboardManager {
     // --- Monitoring / Reading ---
 
     pub fn get_current_text(&mut self) -> Result<String, arboard::Error> {
-        // We unwrap internal map error because arboard::Error is the expected return type here
-        // for the monitoring loop in main.rs
-        Clipboard::new()?.get_text()
+        read_clipboard_text()
     }
 
     /// Try to get HTML content from clipboard. Returns None if not available.
     pub fn get_current_html(&self) -> Option<String> {
-        let mut clipboard = get_system_clipboard().ok()?;
-        clipboard.get().html().ok()
+        read_clipboard_html()
     }
 
     pub fn get_current_image(
         &mut self,
     ) -> Result<Option<(ImageData<'static>, u64)>, arboard::Error> {
-        let mut clipboard = Clipboard::new()?;
-
-        match clipboard.get_image() {
-            Ok(image) => {
-                let hash = calculate_hash(&image.bytes);
-                let owned = ImageData {
-                    width: image.width,
-                    height: image.height,
-                    bytes: image.bytes.into_owned().into(),
-                };
-                Ok(Some((owned, hash)))
-            }
-            Err(arboard::Error::ContentNotAvailable) => Ok(None),
-            Err(e) => Err(e),
-        }
+        read_clipboard_image()
     }
 
     // --- Adding Items ---
@@ -384,6 +442,24 @@ impl ClipboardManager {
             hash,
         );
 
+        self.insert_item(item.clone());
+        Some(item)
+    }
+
+    /// Add an already-encoded image (base64 PNG) to history.
+    /// Encoding is expected to happen before acquiring the lock.
+    pub fn add_image_encoded(
+        &mut self,
+        base64: String,
+        width: u32,
+        height: u32,
+        hash: u64,
+    ) -> Option<ClipboardItem> {
+        if self.should_skip_image(hash) {
+            return None;
+        }
+
+        let item = ClipboardItem::new_image(base64, width, height, hash);
         self.insert_item(item.clone());
         Some(item)
     }
@@ -464,17 +540,7 @@ impl ClipboardManager {
     }
 
     fn convert_image_to_base64(&self, image_data: &ImageData<'_>) -> Option<String> {
-        let img = DynamicImage::ImageRgba8(
-            image::RgbaImage::from_raw(
-                image_data.width as u32,
-                image_data.height as u32,
-                image_data.bytes.to_vec(),
-            )?, // Returns None if dimensions don't match bytes
-        );
-
-        let mut buffer = Cursor::new(Vec::new());
-        img.write_to(&mut buffer, ImageFormat::Png).ok()?;
-        Some(BASE64.encode(buffer.get_ref()))
+        encode_image_to_base64(image_data)
     }
 
     fn insert_item(&mut self, item: ClipboardItem) {
@@ -510,7 +576,18 @@ impl ClipboardManager {
     // --- Accessors ---
 
     pub fn get_history(&self) -> Vec<ClipboardItem> {
-        self.history.clone()
+        // Return lightweight copies (image base64 stripped) to keep IPC
+        // payloads small. Full image content is fetched on demand via
+        // get_item_content.
+        self.history
+            .iter()
+            .map(ClipboardItem::lightweight)
+            .collect()
+    }
+
+    /// Returns the full item (including image base64) by id.
+    pub fn get_item_content(&self, id: &str) -> Option<ClipboardItem> {
+        self.history.iter().find(|item| item.id == id).cloned()
     }
 
     pub fn get_item(&self, id: &str) -> Option<&ClipboardItem> {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,7 +12,10 @@ use tauri::{
     WindowEvent,
 };
 use win11_clipboard_history_lib::autostart_manager;
-use win11_clipboard_history_lib::clipboard_manager::{ClipboardItem, ClipboardManager};
+use win11_clipboard_history_lib::clipboard_manager::{
+    calculate_hash, encode_image_to_base64, read_clipboard_html, read_clipboard_image,
+    read_clipboard_text, ClipboardItem, ClipboardManager,
+};
 use win11_clipboard_history_lib::config_manager::{resolve_window_position, ConfigManager};
 use win11_clipboard_history_lib::emoji_manager::{EmojiManager, EmojiUsage};
 use win11_clipboard_history_lib::focus_manager::x11_robust_activate;
@@ -51,6 +54,11 @@ pub struct AppState {
 #[tauri::command]
 fn get_history(state: State<AppState>) -> Vec<ClipboardItem> {
     state.clipboard_manager.lock().get_history()
+}
+
+#[tauri::command]
+fn get_item_content(state: State<AppState>, id: String) -> Option<ClipboardItem> {
+    state.clipboard_manager.lock().get_item_content(&id)
 }
 
 #[tauri::command]
@@ -703,47 +711,76 @@ fn start_clipboard_watcher(app: AppHandle, clipboard_manager: Arc<Mutex<Clipboar
             std::thread::sleep(Duration::from_millis(500));
             cleanup_counter += 1;
 
-            let mut manager = clipboard_manager.lock();
-
-            // Background cleanup every ~30 seconds (60 * 500ms)
+            // Background cleanup every ~30 seconds (60 * 500ms).
+            // Load settings (disk I/O) before taking the manager lock.
             if cleanup_counter >= 60 {
                 cleanup_counter = 0;
-                let settings = UserSettingsManager::new().load();
-                let interval_in_minutes = settings.auto_delete_interval_in_minutes();
+                let interval_in_minutes = UserSettingsManager::new()
+                    .load()
+                    .auto_delete_interval_in_minutes();
 
-                if interval_in_minutes > 0 && manager.cleanup_old_items(interval_in_minutes) {
-                    println!("[Watcher] Background cleanup triggered sync");
-                    let _ = app.emit("history-cleared", ());
-                }
-            }
-
-            // Text
-            if let Ok(text) = manager.get_current_text() {
-                if !text.is_empty() {
-                    let text_hash =
-                        win11_clipboard_history_lib::clipboard_manager::calculate_hash(&text);
-
-                    if Some(text_hash) != last_text_hash {
-                        last_text_hash = Some(text_hash);
-                        last_image_hash = None;
-
-                        // Try to get HTML content for rich text support
-                        let html = manager.get_current_html();
-
-                        if let Some(item) = manager.add_text(text, html) {
-                            let _ = app.emit("clipboard-changed", &item);
-                        }
+                if interval_in_minutes > 0 {
+                    let mut manager = clipboard_manager.lock();
+                    if manager.cleanup_old_items(interval_in_minutes) {
+                        drop(manager);
+                        println!("[Watcher] Background cleanup triggered sync");
+                        let _ = app.emit("history-cleared", ());
                     }
                 }
             }
 
-            // Image
-            if let Ok(Some((image_data, hash))) = manager.get_current_image() {
-                if Some(hash) != last_image_hash {
-                    last_image_hash = Some(hash);
-                    last_text_hash = None;
-                    if let Some(item) = manager.add_image(image_data, hash) {
-                        let _ = app.emit("clipboard-changed", &item);
+            // Read the system clipboard WITHOUT holding the manager lock.
+            // arboard/X11 clipboard reads can block, and doing so under the
+            // lock would freeze every UI command that needs it.
+            let text = read_clipboard_text().ok();
+
+            // If the text changed, fetch the HTML variant too (outside the lock).
+            let mut text_to_add: Option<(String, Option<String>)> = None;
+            if let Some(text) = text {
+                if !text.is_empty() {
+                    let text_hash = calculate_hash(&text);
+                    if Some(text_hash) != last_text_hash {
+                        last_text_hash = Some(text_hash);
+                        last_image_hash = None;
+                        let html = read_clipboard_html();
+                        text_to_add = Some((text, html));
+                    }
+                }
+            }
+
+            // Encode image data (CPU heavy for large images) outside the lock.
+            // Only encode when the hash changed: re-encoding an unchanged
+            // image every poll would defeat the purpose of the refactor.
+            let image = read_clipboard_image()
+                .ok()
+                .flatten()
+                .and_then(|(data, hash)| {
+                    if Some(hash) == last_image_hash {
+                        return None;
+                    }
+                    let base64 = encode_image_to_base64(&data);
+                    Some((base64, data.width, data.height, hash))
+                });
+
+            // Apply changes under a brief lock (dedupe + insert + persist).
+            let mut manager = clipboard_manager.lock();
+
+            if let Some((text, html)) = text_to_add {
+                if let Some(item) = manager.add_text(text, html) {
+                    // Emit a lightweight payload: the frontend ignores it and
+                    // refetches via get_history, so avoid shipping image base64.
+                    let _ = app.emit("clipboard-changed", &item.lightweight());
+                }
+            }
+
+            if let Some((base64, width, height, hash)) = image {
+                last_image_hash = Some(hash);
+                last_text_hash = None;
+                if let Some(base64) = base64 {
+                    if let Some(item) =
+                        manager.add_image_encoded(base64, width as u32, height as u32, hash)
+                    {
+                        let _ = app.emit("clipboard-changed", &item.lightweight());
                     }
                 }
             }
@@ -1077,6 +1114,7 @@ fn main() {
         })
         .invoke_handler(tauri::generate_handler![
             get_history,
+            get_item_content,
             clear_history,
             delete_item,
             toggle_pin,

--- a/src-tauri/src/user_settings.rs
+++ b/src-tauri/src/user_settings.rs
@@ -31,6 +31,10 @@ pub struct UserSettings {
     #[serde(default = "default_true")]
     pub enable_ui_polish: bool,
 
+    /// Clear the active picker's search query and focus the search box every time the window is shown
+    #[serde(default = "default_true")]
+    pub clear_search_on_open: bool,
+
     // --- History Settings ---
     /// Maximum number of clipboard history items to keep (1 to 100000)
     #[serde(default = "default_max_history_size")]
@@ -92,6 +96,7 @@ impl Default for UserSettings {
             enable_dynamic_tray_icon: true,
             enable_smart_actions: true,
             enable_ui_polish: true,
+            clear_search_on_open: true,
             max_history_size: default_max_history_size(),
             auto_delete_interval: 0,
             auto_delete_unit: "hours".to_string(),
@@ -233,6 +238,7 @@ mod tests {
         assert_eq!(settings.theme_mode, "system");
         assert!((settings.dark_background_opacity - 0.70).abs() < f32::EPSILON);
         assert!((settings.light_background_opacity - 0.70).abs() < f32::EPSILON);
+        assert!(settings.clear_search_on_open);
     }
 
     #[test]

--- a/src/ClipboardApp.tsx
+++ b/src/ClipboardApp.tsx
@@ -94,6 +94,13 @@ function ClipboardApp() {
   const [settings, setSettings] = useState<UserSettings>(DEFAULT_SETTINGS)
   const [settingsLoaded, setSettingsLoaded] = useState(false)
 
+  // Search queries for the pickers, owned here so they survive tab switches.
+  // Cleared when the window is (re)opened if the "clear search on open" setting is enabled.
+  const [pickerSearch, setPickerSearch] = useState({ emoji: '', kaomoji: '', symbols: '' })
+  const updatePickerSearch = useCallback((tab: 'emoji' | 'kaomoji' | 'symbols', value: string) => {
+    setPickerSearch((prev) => ({ ...prev, [tab]: value }))
+  }, [])
+
   const renderingEnv = useRenderingEnv()
   const isDark = useThemeMode(settings.theme_mode)
 
@@ -207,7 +214,12 @@ function ClipboardApp() {
 
   // Handle window-shown event for focus management (registered once)
   useEffect(() => {
-    const focusFirstItem = () => {
+    const onWindowShown = () => {
+      // Clear all picker searches when the window is reopened, if enabled
+      if (clearSearchOnOpenRef.current) {
+        setPickerSearch({ emoji: '', kaomoji: '', symbols: '' })
+      }
+
       const currentTab = activeTabRef.current
 
       // Clipboard tab focus is handled inside ClipboardTab component
@@ -224,7 +236,7 @@ function ClipboardApp() {
     }
 
     // Listen to window-shown event (emitted from Rust when window is toggled visible)
-    const unlistenWindowShown = listen('window-shown', focusFirstItem)
+    const unlistenWindowShown = listen('window-shown', onWindowShown)
 
     return () => {
       unlistenWindowShown.then((unlisten) => unlisten())
@@ -270,6 +282,8 @@ function ClipboardApp() {
             isDark={isDark}
             opacity={secondaryOpacity}
             clearSearchOnOpen={settings.clear_search_on_open}
+            searchQuery={pickerSearch.emoji}
+            onSearchChange={(value) => updatePickerSearch('emoji', value)}
           />
         )
 
@@ -283,6 +297,8 @@ function ClipboardApp() {
             opacity={secondaryOpacity}
             customKaomojis={settings.custom_kaomojis}
             clearSearchOnOpen={settings.clear_search_on_open}
+            searchQuery={pickerSearch.kaomoji}
+            onSearchChange={(value) => updatePickerSearch('kaomoji', value)}
           />
         )
 
@@ -292,6 +308,8 @@ function ClipboardApp() {
             isDark={isDark}
             opacity={secondaryOpacity}
             clearSearchOnOpen={settings.clear_search_on_open}
+            searchQuery={pickerSearch.symbols}
+            onSearchChange={(value) => updatePickerSearch('symbols', value)}
           />
         )
 

--- a/src/ClipboardApp.tsx
+++ b/src/ClipboardApp.tsx
@@ -23,6 +23,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   enable_smart_actions: true,
   enable_ui_polish: true,
   enable_dynamic_tray_icon: true,
+  clear_search_on_open: true,
   max_history_size: 50,
   auto_delete_interval: 0,
   auto_delete_unit: 'hours',
@@ -193,24 +194,32 @@ function ClipboardApp() {
 
   // Use refs to store current values for the focus handler (to avoid re-registering listener)
   const activeTabRef = useRef(activeTab)
+  const clearSearchOnOpenRef = useRef(settings.clear_search_on_open)
 
   // Keep refs in sync
   useEffect(() => {
     activeTabRef.current = activeTab
   }, [activeTab])
 
+  useEffect(() => {
+    clearSearchOnOpenRef.current = settings.clear_search_on_open
+  }, [settings.clear_search_on_open])
+
   // Handle window-shown event for focus management (registered once)
   useEffect(() => {
     const focusFirstItem = () => {
-      // Small delay to ensure the window is fully rendered and focused
-      setTimeout(() => {
-        const currentTab = activeTabRef.current
+      const currentTab = activeTabRef.current
 
-        if (currentTab !== 'clipboard') {
-          // Focus the first tab button if on other tabs
-          // Clipboard tab focus is handled inside ClipboardTab component
-          tabBarRef.current?.focusFirstTab()
-        }
+      // Clipboard tab focus is handled inside ClipboardTab component
+      if (currentTab === 'clipboard') return
+
+      // Emoji/Kaomoji/Symbol pickers clear and focus their search bar on
+      // window-shown when "clear search on open" is enabled, so skip tab focus.
+      if (clearSearchOnOpenRef.current) return
+
+      // Fallback: focus the first tab button
+      setTimeout(() => {
+        tabBarRef.current?.focusFirstTab()
       }, 100)
     }
 
@@ -256,7 +265,13 @@ function ClipboardApp() {
         )
 
       case 'emoji':
-        return <EmojiPicker isDark={isDark} opacity={secondaryOpacity} />
+        return (
+          <EmojiPicker
+            isDark={isDark}
+            opacity={secondaryOpacity}
+            clearSearchOnOpen={settings.clear_search_on_open}
+          />
+        )
 
       // case 'gifs':
       //   return <GifPicker isDark={isDark} opacity={secondaryOpacity} />
@@ -267,11 +282,18 @@ function ClipboardApp() {
             isDark={isDark}
             opacity={secondaryOpacity}
             customKaomojis={settings.custom_kaomojis}
+            clearSearchOnOpen={settings.clear_search_on_open}
           />
         )
 
       case 'symbols':
-        return <SymbolPicker isDark={isDark} opacity={secondaryOpacity} />
+        return (
+          <SymbolPicker
+            isDark={isDark}
+            opacity={secondaryOpacity}
+            clearSearchOnOpen={settings.clear_search_on_open}
+          />
+        )
 
       default:
         return null

--- a/src/SettingsApp.tsx
+++ b/src/SettingsApp.tsx
@@ -21,6 +21,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   enable_smart_actions: true,
   enable_ui_polish: true,
   enable_dynamic_tray_icon: true,
+  clear_search_on_open: true,
   max_history_size: 50,
   custom_kaomojis: [],
   ui_scale: 1,

--- a/src/components/ClipboardTab.tsx
+++ b/src/components/ClipboardTab.tsx
@@ -10,6 +10,7 @@ import { SearchBar } from './common/SearchBar'
 import { EmptyState } from './EmptyState'
 import { HistoryItem } from './HistoryItem'
 import { useHistoryKeyboardNavigation } from '../hooks/useHistoryKeyboardNavigation'
+import { useResetSearchOnWindowShown } from '../hooks/useResetSearchOnWindowShown'
 
 export function ClipboardTab(props: {
   history: ClipboardItem[]
@@ -184,17 +185,11 @@ export function ClipboardTab(props: {
     }
   }, [isSearchVisible])
 
-  // Reset search when window is shown (reopened)
-  useEffect(() => {
-    const resetSearch = () => {
-      setIsSearchVisible(false)
-      setSearchQuery('')
-    }
-    const unlistenWindowShown = listen('window-shown', resetSearch)
-    return () => {
-      unlistenWindowShown.then((u) => u())
-    }
-  }, [])
+  // Reset search when window is shown (reopened) if the setting is enabled
+  useResetSearchOnWindowShown(settings.clear_search_on_open, () => {
+    if (isSearchVisible) setIsSearchVisible(false)
+    if (searchQuery !== '') setSearchQuery('')
+  })
 
   // Filter history by search query
   const filteredHistory = useMemo(() => {

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -138,12 +138,19 @@ export interface EmojiPickerProps {
   opacity: number
   /** Clear the search query and focus the search box when the window is shown */
   clearSearchOnOpen?: boolean
+  /** Controlled search query, owned by the parent so it survives tab switches */
+  searchQuery: string
+  onSearchChange: (value: string) => void
 }
 
-export function EmojiPicker({ isDark, opacity, clearSearchOnOpen = false }: EmojiPickerProps) {
+export function EmojiPicker({
+  isDark,
+  opacity,
+  clearSearchOnOpen = false,
+  searchQuery,
+  onSearchChange,
+}: EmojiPickerProps) {
   const {
-    searchQuery,
-    setSearchQuery,
     selectedCategory,
     setSelectedCategory,
     categories,
@@ -151,7 +158,7 @@ export function EmojiPicker({ isDark, opacity, clearSearchOnOpen = false }: Emoj
     recentEmojis,
     isLoading,
     pasteEmoji,
-  } = useEmojiPicker()
+  } = useEmojiPicker(searchQuery)
 
   const [hoveredEmoji, setHoveredEmoji] = useState<Emoji | null>(null)
 
@@ -169,7 +176,7 @@ export function EmojiPicker({ isDark, opacity, clearSearchOnOpen = false }: Emoj
 
   // Clear search and focus the search box when the window is shown
   useResetSearchOnWindowShown(clearSearchOnOpen, () => {
-    if (searchQuery !== '') setSearchQuery('')
+    if (searchQuery !== '') onSearchChange('')
     if (recentFocusedIndex !== 0) setRecentFocusedIndex(0)
     if (mainFocusedIndex !== 0) setMainFocusedIndex(0)
     requestAnimationFrame(() => searchInputRef.current?.focus())
@@ -177,11 +184,11 @@ export function EmojiPicker({ isDark, opacity, clearSearchOnOpen = false }: Emoj
 
   const handleSearchChange = useCallback(
     (val: string) => {
-      setSearchQuery(val)
+      onSearchChange(val)
       setRecentFocusedIndex(0)
       setMainFocusedIndex(0)
     },
-    [setSearchQuery]
+    [onSearchChange]
   )
 
   const handleCategorySelect = useCallback(

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -3,6 +3,7 @@ import { Grid, useGridRef } from 'react-window'
 import { clsx } from 'clsx'
 import { Clock } from 'lucide-react'
 import { useEmojiPicker } from '../hooks/useEmojiPicker'
+import { useResetSearchOnWindowShown } from '../hooks/useResetSearchOnWindowShown'
 import { SearchBar } from './common/SearchBar'
 import { SectionHeader } from './common/SectionHeader'
 import type { Emoji } from '../services/emojiService'
@@ -135,9 +136,11 @@ function EmojiGridCell({
 export interface EmojiPickerProps {
   isDark: boolean
   opacity: number
+  /** Clear the search query and focus the search box when the window is shown */
+  clearSearchOnOpen?: boolean
 }
 
-export function EmojiPicker({ isDark, opacity }: EmojiPickerProps) {
+export function EmojiPicker({ isDark, opacity, clearSearchOnOpen = false }: EmojiPickerProps) {
   const {
     searchQuery,
     setSearchQuery,
@@ -157,11 +160,20 @@ export function EmojiPicker({ isDark, opacity }: EmojiPickerProps) {
   const gridRef = useGridRef(null)
   const recentGridRef = useRef<HTMLDivElement>(null)
   const mainGridContainerRef = useRef<HTMLDivElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
 
   // Roving tabindex states
   const [recentFocusedIndex, setRecentFocusedIndex] = useState(0)
   const [mainFocusedIndex, setMainFocusedIndex] = useState(0)
   const [categoryFocusedIndex, setCategoryFocusedIndex] = useState(0)
+
+  // Clear search and focus the search box when the window is shown
+  useResetSearchOnWindowShown(clearSearchOnOpen, () => {
+    if (searchQuery !== '') setSearchQuery('')
+    if (recentFocusedIndex !== 0) setRecentFocusedIndex(0)
+    if (mainFocusedIndex !== 0) setMainFocusedIndex(0)
+    requestAnimationFrame(() => searchInputRef.current?.focus())
+  })
 
   const handleSearchChange = useCallback(
     (val: string) => {
@@ -227,6 +239,7 @@ export function EmojiPicker({ isDark, opacity }: EmojiPickerProps) {
     <PickerLayout
       header={
         <SearchBar
+          ref={searchInputRef}
           value={searchQuery}
           onChange={handleSearchChange}
           placeholder="Search emojis..."

--- a/src/components/FeaturesSection.tsx
+++ b/src/components/FeaturesSection.tsx
@@ -13,6 +13,11 @@ const FEATURES = [
     label: 'UI Polish',
     desc: 'Enable animations and compact mode support.',
   },
+  {
+    key: 'clear_search_on_open',
+    label: 'Clear Search on Open',
+    desc: 'Clear the search box and focus it every time the window opens.',
+  },
 ] as const
 
 export function FeaturesSection({

--- a/src/components/HistoryItem/_HistoryItemContent.tsx
+++ b/src/components/HistoryItem/_HistoryItemContent.tsx
@@ -1,5 +1,7 @@
 import { clsx } from 'clsx'
+import { useEffect, useRef, useState } from 'react'
 import type { ClipboardItem } from '../../types/clipboard'
+import { useLazyImageContent } from '../../hooks/useLazyImageContent'
 
 export function TextContent({
   item,
@@ -36,26 +38,48 @@ export function ImageContent({
   isDark: boolean
   effectiveCompact: boolean
 }) {
-  if (item.content.type !== 'Image') return null
-  const { width, height, base64 } = item.content.data
+  const wrapperRef = useRef<HTMLDivElement | null>(null)
+  const [inView, setInView] = useState(false)
 
-  if (effectiveCompact) {
+  useEffect(() => {
+    const el = wrapperRef.current
+    if (!el) return
+    const observer = new IntersectionObserver(
+      (entries) => setInView(entries[0]?.isIntersecting ?? false),
+      { rootMargin: '150px 0px' }
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  const isImage = item.content.type === 'Image'
+  const base64 = item.content.type === 'Image' ? item.content.data.base64 : ''
+  const wantsFullImage = isImage && !effectiveCompact
+  const lazyBase64 = useLazyImageContent(item.id, wantsFullImage && inView && !base64)
+  const src = base64 || lazyBase64
+
+  if (item.content.type !== 'Image') return null
+  const { width, height } = item.content.data
+
+  if (effectiveCompact || !src) {
     return (
-      <span
-        className={clsx(
-          'text-sm italic',
-          isDark ? 'text-win11-text-tertiary' : 'text-win11Light-text-secondary'
-        )}
-      >
-        Image ({width}×{height})
-      </span>
+      <div ref={wrapperRef}>
+        <span
+          className={clsx(
+            'text-sm italic',
+            isDark ? 'text-win11-text-tertiary' : 'text-win11Light-text-secondary'
+          )}
+        >
+          Image ({width}×{height})
+        </span>
+      </div>
     )
   }
 
   return (
-    <div className="relative">
+    <div ref={wrapperRef} className="relative">
       <img
-        src={`data:image/png;base64,${base64}`}
+        src={`data:image/png;base64,${src}`}
         alt="Clipboard image"
         className="max-w-full max-h-24 rounded object-contain bg-black/10"
       />

--- a/src/components/KaomojiPicker.tsx
+++ b/src/components/KaomojiPicker.tsx
@@ -17,6 +17,9 @@ interface KaomojiPickerProps {
   customKaomojis?: CustomKaomoji[]
   /** Clear the search query and focus the search box when the window is shown */
   clearSearchOnOpen?: boolean
+  /** Controlled search query, owned by the parent so it survives tab switches */
+  searchQuery: string
+  onSearchChange: (value: string) => void
 }
 
 export function KaomojiPicker({
@@ -24,8 +27,9 @@ export function KaomojiPicker({
   opacity,
   customKaomojis = [],
   clearSearchOnOpen = false,
+  searchQuery,
+  onSearchChange,
 }: KaomojiPickerProps) {
-  const [searchQuery, setSearchQuery] = useState('')
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
 
   const [categoryFocusedIndex, setCategoryFocusedIndex] = useState(0)
@@ -39,7 +43,7 @@ export function KaomojiPicker({
 
   // Clear search and focus the search box when the window is shown
   useResetSearchOnWindowShown(clearSearchOnOpen, () => {
-    if (searchQuery !== '') setSearchQuery('')
+    if (searchQuery !== '') onSearchChange('')
     if (categoryFocusedIndex !== 0) setCategoryFocusedIndex(0)
     if (gridFocusedIndex !== 0) setGridFocusedIndex(0)
     requestAnimationFrame(() => searchInputRef.current?.focus())
@@ -94,7 +98,7 @@ export function KaomojiPicker({
           ref={searchInputRef}
           value={searchQuery}
           onChange={(val: string) => {
-            setSearchQuery(val)
+            onSearchChange(val)
             setCategoryFocusedIndex(0)
             setGridFocusedIndex(0)
           }}

--- a/src/components/KaomojiPicker.tsx
+++ b/src/components/KaomojiPicker.tsx
@@ -4,6 +4,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { KAOMOJI_CATEGORIES, getKaomojis } from '../services/kaomojiService'
 import { SearchBar } from './common/SearchBar'
 import type { CustomKaomoji } from '../types/clipboard'
+import { useResetSearchOnWindowShown } from '../hooks/useResetSearchOnWindowShown'
 
 import { PickerLayout } from './common/PickerLayout'
 import { CategoryStrip } from './common/CategoryStrip'
@@ -14,9 +15,16 @@ interface KaomojiPickerProps {
   isDark: boolean
   opacity: number
   customKaomojis?: CustomKaomoji[]
+  /** Clear the search query and focus the search box when the window is shown */
+  clearSearchOnOpen?: boolean
 }
 
-export function KaomojiPicker({ isDark, opacity, customKaomojis = [] }: KaomojiPickerProps) {
+export function KaomojiPicker({
+  isDark,
+  opacity,
+  customKaomojis = [],
+  clearSearchOnOpen = false,
+}: KaomojiPickerProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
 
@@ -27,6 +35,15 @@ export function KaomojiPicker({ isDark, opacity, customKaomojis = [] }: KaomojiP
     null
   )
   const gridContainerRef = useRef<HTMLDivElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  // Clear search and focus the search box when the window is shown
+  useResetSearchOnWindowShown(clearSearchOnOpen, () => {
+    if (searchQuery !== '') setSearchQuery('')
+    if (categoryFocusedIndex !== 0) setCategoryFocusedIndex(0)
+    if (gridFocusedIndex !== 0) setGridFocusedIndex(0)
+    requestAnimationFrame(() => searchInputRef.current?.focus())
+  })
 
   const { containerRef, dimensions } = useResponsiveGrid()
 
@@ -74,6 +91,7 @@ export function KaomojiPicker({ isDark, opacity, customKaomojis = [] }: KaomojiP
     <PickerLayout
       header={
         <SearchBar
+          ref={searchInputRef}
           value={searchQuery}
           onChange={(val: string) => {
             setSearchQuery(val)

--- a/src/components/SymbolPicker.tsx
+++ b/src/components/SymbolPicker.tsx
@@ -3,6 +3,7 @@ import { Grid, useGridRef } from 'react-window'
 import { clsx } from 'clsx'
 import { Clock } from 'lucide-react'
 import { useSymbolPicker } from '../hooks/useSymbolPicker'
+import { useResetSearchOnWindowShown } from '../hooks/useResetSearchOnWindowShown'
 import { SearchBar } from './common/SearchBar'
 import { SectionHeader } from './common/SectionHeader'
 import type { SymbolItem } from '../services/symbolService'
@@ -133,9 +134,11 @@ function SymbolGridCell({
 export interface SymbolPickerProps {
   isDark: boolean
   opacity: number
+  /** Clear the search query and focus the search box when the window is shown */
+  clearSearchOnOpen?: boolean
 }
 
-export function SymbolPicker({ isDark, opacity }: SymbolPickerProps) {
+export function SymbolPicker({ isDark, opacity, clearSearchOnOpen = false }: SymbolPickerProps) {
   const {
     searchQuery,
     setSearchQuery,
@@ -155,11 +158,20 @@ export function SymbolPicker({ isDark, opacity }: SymbolPickerProps) {
   const gridRef = useGridRef(null)
   const recentGridRef = useRef<HTMLDivElement>(null)
   const mainGridContainerRef = useRef<HTMLDivElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
 
   // Roving tabindex states
   const [recentFocusedIndex, setRecentFocusedIndex] = useState(0)
   const [mainFocusedIndex, setMainFocusedIndex] = useState(0)
   const [categoryFocusedIndex, setCategoryFocusedIndex] = useState(0)
+
+  // Clear search and focus the search box when the window is shown
+  useResetSearchOnWindowShown(clearSearchOnOpen, () => {
+    if (searchQuery !== '') setSearchQuery('')
+    if (recentFocusedIndex !== 0) setRecentFocusedIndex(0)
+    if (mainFocusedIndex !== 0) setMainFocusedIndex(0)
+    requestAnimationFrame(() => searchInputRef.current?.focus())
+  })
 
   const handleSearchChange = useCallback(
     (val: string) => {
@@ -218,6 +230,7 @@ export function SymbolPicker({ isDark, opacity }: SymbolPickerProps) {
     <PickerLayout
       header={
         <SearchBar
+          ref={searchInputRef}
           value={searchQuery}
           onChange={handleSearchChange}
           placeholder="Search symbols..."

--- a/src/components/SymbolPicker.tsx
+++ b/src/components/SymbolPicker.tsx
@@ -136,19 +136,26 @@ export interface SymbolPickerProps {
   opacity: number
   /** Clear the search query and focus the search box when the window is shown */
   clearSearchOnOpen?: boolean
+  /** Controlled search query, owned by the parent so it survives tab switches */
+  searchQuery: string
+  onSearchChange: (value: string) => void
 }
 
-export function SymbolPicker({ isDark, opacity, clearSearchOnOpen = false }: SymbolPickerProps) {
+export function SymbolPicker({
+  isDark,
+  opacity,
+  clearSearchOnOpen = false,
+  searchQuery,
+  onSearchChange,
+}: SymbolPickerProps) {
   const {
-    searchQuery,
-    setSearchQuery,
     selectedCategory,
     setSelectedCategory,
     categories,
     filteredSymbols,
     recentSymbols,
     pasteSymbol,
-  } = useSymbolPicker()
+  } = useSymbolPicker(searchQuery)
 
   const [hoveredSymbol, setHoveredSymbol] = useState<SymbolItem | null>(null)
 
@@ -167,7 +174,7 @@ export function SymbolPicker({ isDark, opacity, clearSearchOnOpen = false }: Sym
 
   // Clear search and focus the search box when the window is shown
   useResetSearchOnWindowShown(clearSearchOnOpen, () => {
-    if (searchQuery !== '') setSearchQuery('')
+    if (searchQuery !== '') onSearchChange('')
     if (recentFocusedIndex !== 0) setRecentFocusedIndex(0)
     if (mainFocusedIndex !== 0) setMainFocusedIndex(0)
     requestAnimationFrame(() => searchInputRef.current?.focus())
@@ -175,11 +182,11 @@ export function SymbolPicker({ isDark, opacity, clearSearchOnOpen = false }: Sym
 
   const handleSearchChange = useCallback(
     (val: string) => {
-      setSearchQuery(val)
+      onSearchChange(val)
       setRecentFocusedIndex(0)
       setMainFocusedIndex(0)
     },
-    [setSearchQuery]
+    [onSearchChange]
   )
 
   const handleCategorySelect = useCallback(

--- a/src/components/common/SymbolPicker.tsx
+++ b/src/components/common/SymbolPicker.tsx
@@ -127,16 +127,15 @@ export interface SymbolPickerProps {
 }
 
 export function SymbolPicker({ isDark, opacity }: SymbolPickerProps) {
+  const [searchQuery, setSearchQuery] = useState('')
   const {
-    searchQuery,
-    setSearchQuery,
     selectedCategory,
     setSelectedCategory,
     categories,
     filteredSymbols,
     recentSymbols,
     pasteSymbol,
-  } = useSymbolPicker()
+  } = useSymbolPicker(searchQuery)
 
   const [hoveredSymbol, setHoveredSymbol] = useState<SymbolItem | null>(null)
 

--- a/src/hooks/useEmojiPicker.ts
+++ b/src/hooks/useEmojiPicker.ts
@@ -13,8 +13,7 @@ interface RecentEmoji {
   use_count: number
 }
 
-export function useEmojiPicker() {
-  const [searchQuery, setSearchQuery] = useState('')
+export function useEmojiPicker(searchQuery: string) {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
   const [recentEmojis, setRecentEmojis] = useState<Emoji[]>([])
   const [isLoading, setIsLoading] = useState(true)
@@ -89,7 +88,6 @@ export function useEmojiPicker() {
 
   return {
     searchQuery,
-    setSearchQuery,
     selectedCategory,
     setSelectedCategory,
     categories,

--- a/src/hooks/useLazyImageContent.ts
+++ b/src/hooks/useLazyImageContent.ts
@@ -5,6 +5,11 @@
  * full image content is fetched on demand via `get_item_content` when an
  * item scrolls into view. Results are cached per item id so switching tabs
  * does not refetch.
+ *
+ * State is initialized from the per-id cache on mount. The caller is expected
+ * to render each item under a stable `key={item.id}` (as HistoryItem does), so
+ * an instance never serves a previous item's image and no render-phase state
+ * adjustment is needed.
  */
 import { useState, useEffect } from 'react'
 import { invoke } from '@tauri-apps/api/core'
@@ -15,16 +20,21 @@ const imageContentCache = new Map<string, string>()
 /** Set of item ids currently being fetched, to avoid duplicate requests. */
 const imageContentInFlight = new Set<string>()
 
+/** Upper bound for the cache; entries beyond this are evicted oldest-first. */
+const IMAGE_CACHE_MAX_SIZE = 256
+
+function cacheImageContent(id: string, base64: string) {
+  imageContentCache.set(id, base64)
+  if (imageContentCache.size > IMAGE_CACHE_MAX_SIZE) {
+    const oldest = imageContentCache.keys().next().value
+    if (oldest !== undefined) {
+      imageContentCache.delete(oldest)
+    }
+  }
+}
+
 export function useLazyImageContent(id: string, shouldLoad: boolean): string {
   const [base64, setBase64] = useState(() => imageContentCache.get(id) ?? '')
-
-  // Adjust state when the item id changes (e.g. virtualized row reuse) so a
-  // reused instance never shows a previous item's image.
-  const [prevId, setPrevId] = useState(id)
-  if (prevId !== id) {
-    setPrevId(id)
-    setBase64(imageContentCache.get(id) ?? '')
-  }
 
   useEffect(() => {
     if (!shouldLoad || base64 || imageContentCache.has(id) || imageContentInFlight.has(id)) {
@@ -34,7 +44,7 @@ export function useLazyImageContent(id: string, shouldLoad: boolean): string {
     invoke<ClipboardItem>('get_item_content', { id })
       .then((item) => {
         if (item && item.content.type === 'Image') {
-          imageContentCache.set(id, item.content.data.base64)
+          cacheImageContent(id, item.content.data.base64)
           setBase64(item.content.data.base64)
         }
       })

--- a/src/hooks/useLazyImageContent.ts
+++ b/src/hooks/useLazyImageContent.ts
@@ -1,0 +1,52 @@
+/**
+ * Lazy image content hook.
+ *
+ * The backend strips image base64 from history payloads to keep IPC small;
+ * full image content is fetched on demand via `get_item_content` when an
+ * item scrolls into view. Results are cached per item id so switching tabs
+ * does not refetch.
+ */
+import { useState, useEffect } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+import type { ClipboardItem } from '../types/clipboard'
+
+/** Cache of fetched image base64 keyed by item id. */
+const imageContentCache = new Map<string, string>()
+/** Set of item ids currently being fetched, to avoid duplicate requests. */
+const imageContentInFlight = new Set<string>()
+
+export function useLazyImageContent(id: string, shouldLoad: boolean): string {
+  const [base64, setBase64] = useState(() => imageContentCache.get(id) ?? '')
+
+  // Adjust state when the item id changes (e.g. virtualized row reuse) so a
+  // reused instance never shows a previous item's image.
+  const [prevId, setPrevId] = useState(id)
+  if (prevId !== id) {
+    setPrevId(id)
+    setBase64(imageContentCache.get(id) ?? '')
+  }
+
+  useEffect(() => {
+    if (!shouldLoad || base64 || imageContentCache.has(id) || imageContentInFlight.has(id)) {
+      return
+    }
+    imageContentInFlight.add(id)
+    invoke<ClipboardItem>('get_item_content', { id })
+      .then((item) => {
+        if (item && item.content.type === 'Image') {
+          imageContentCache.set(id, item.content.data.base64)
+          setBase64(item.content.data.base64)
+        }
+      })
+      .catch((err) => {
+        if (import.meta.env.DEV) {
+          console.warn(`Failed to load image content for "${id}":`, err)
+        }
+      })
+      .finally(() => {
+        imageContentInFlight.delete(id)
+      })
+  }, [id, shouldLoad, base64])
+
+  return base64
+}

--- a/src/hooks/useResetSearchOnWindowShown.ts
+++ b/src/hooks/useResetSearchOnWindowShown.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from 'react'
+import { listen } from '@tauri-apps/api/event'
+
+/**
+ * Listens for the `window-shown` event and invokes `onReset` when the window is
+ * (re)opened, but only while `enabled` is true.
+ *
+ * Refs keep both `enabled` and `onReset` fresh, so the listener is registered
+ * exactly once and callers never need to worry about stale closures.
+ */
+export function useResetSearchOnWindowShown(enabled: boolean, onReset: () => void) {
+  const enabledRef = useRef(enabled)
+  const onResetRef = useRef(onReset)
+
+  useEffect(() => {
+    enabledRef.current = enabled
+    onResetRef.current = onReset
+  })
+
+  useEffect(() => {
+    const unlisten = listen('window-shown', () => {
+      if (enabledRef.current) onResetRef.current()
+    })
+    return () => {
+      unlisten.then((fn) => fn())
+    }
+  }, [])
+}

--- a/src/hooks/useSymbolPicker.ts
+++ b/src/hooks/useSymbolPicker.ts
@@ -9,8 +9,7 @@ import { getSymbols, getSymbolCategories, type SymbolItem } from '../services/sy
 const RECENT_SYMBOLS_KEY = 'win11_clipboard_recent_symbols'
 const MAX_RECENT_SYMBOLS = 24
 
-export function useSymbolPicker() {
-  const [searchQuery, setSearchQuery] = useState('')
+export function useSymbolPicker(searchQuery: string) {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
 
   const [recentSymbols, setRecentSymbols] = useState<SymbolItem[]>(() => {
@@ -54,7 +53,6 @@ export function useSymbolPicker() {
 
   return {
     searchQuery,
-    setSearchQuery,
     selectedCategory,
     setSelectedCategory,
     categories,

--- a/src/types/clipboard.ts
+++ b/src/types/clipboard.ts
@@ -71,6 +71,7 @@ export interface UserSettings {
   enable_smart_actions: boolean
   enable_ui_polish: boolean
   enable_dynamic_tray_icon: boolean
+  clear_search_on_open: boolean
   max_history_size: number
   auto_delete_interval: number
   auto_delete_unit: 'minutes' | 'hours' | 'days' | 'weeks'


### PR DESCRIPTION
## 📝 Description

This PR contains two logical parts that landed together on this branch.

### 1. Search behavior improvements (#278)
- Adds a **Clear Search on Open** setting (default enabled) that clears the active picker/clipboard search and refocuses the search box whenever the window is reopened.
- Pickers' search queries now **persist across tab switches** (clipboard <-> emoji <-> kaomoji <-> symbols). Search is only cleared on window reopen (when the setting is enabled), not on tab changes.

### 2. Performance / hang fixes
The app could freeze when opening the window or switching tabs, primarily with images in history. Root causes and fixes:

- **Clipboard watcher no longer blocks UI commands.** The watcher thread previously held the `ClipboardManager` lock while reading the *system* clipboard (X11 reads can block) and while PNG-encoding images. Every UI command (`get_history`, `toggle_pin`, …) blocks on that same lock, so a slow clipboard read froze the whole window. Clipboard reads and image encoding now happen **outside the lock**; the lock is held only briefly for dedupe/insert/persist.
- **Image encoding is gated by hash change.** Encoding only runs when the clipboard image hash actually changed, not on every 500 ms poll.
- **History payloads no longer ship image blobs.** `get_history` returns lightweight items (image `base64` stripped); full content is fetched on demand via a new `get_item_content` command. `clipboard-changed` events also emit lightweight payloads.
- **Images lazy-load on scroll.** Thumbnails are fetched and decoded only when they scroll near the viewport, cached per item id, gated by compact mode, and reset when an item id changes. Switching tabs no longer re-decodes the entire list.

## 🔗 Related Issue

- #278 (clear search on open feature)

## 🧪 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI change
- [ ] ♻️ Refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [ ] 🧹 Chore (build process, dependencies, etc.)

## 📸 Screenshots (if applicable)

N/A - no UI change. (Image items now show an `Image (W×H)` placeholder until scrolled into view.)

## ✅ Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format`
- [x] I have tested my changes locally
- [ ] I have added/updated documentation as needed
- [x] My changes don't introduce new warnings
- [ ] I have tested on both X11 and Wayland (if applicable)

## 🖥️ Testing Environment

- **OS**: Pop!_OS 24.04 LTS
- **Desktop Environment**: COSMIC
- **Display Server**: Wayland

## 📋 Additional Notes

- Verified with `make lint`, `make format`, and `cargo test` (15 tests passing).
- Local manual testing (GUI) and the X11/Wayland matrix still need to be filled in by the tester.
- Backend schema is unchanged: image items still serialize with `base64` (just empty in list payloads), so persisted `history.json` remains compatible.

## Summary by Sourcery

Introduce a configurable “clear search on open” behavior for all picker tabs and optimize clipboard image handling to prevent UI hangs and reduce IPC payload size.

New Features:
- Add a clear_search_on_open user setting, default-enabled, to clear picker and clipboard searches and focus search inputs when the window is reopened.
- Persist emoji, kaomoji, and symbol picker search queries across tab switches via app-level controlled state.
- Expose a new get_item_content backend command to fetch full clipboard item contents on demand.

Bug Fixes:
- Prevent UI freezes caused by blocking clipboard reads and image encoding under the ClipboardManager lock by moving those operations outside the lock and gating work on content hash changes.
- Avoid unnecessary re-encoding of unchanged clipboard images by tracking and comparing image hashes.

Enhancements:
- Refactor picker components and hooks to use shared window-shown reset logic and controlled search state owned by the parent app.
- Update feature settings UI to surface the new clear search on open option.

Chores:
- Introduce lazy image loading in history items that fetches image base64 only when items scroll into view, with caching per item id and lightweight history payloads that strip image blobs from list responses and events.