### PR TITLE
fix(emoji): focus grid on open and keep picker open for multi-insert

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -200,15 +200,25 @@ async fn paste_text(
     let _paste_guard = state.paste_gate.lock().await;
 
     // 0. Record usage if applicable
-    let keep_open_tab = match item_type.as_deref() {
-        Some("emoji") => {
-            state.emoji_manager.lock().record_usage(&text);
-            // Keep the emoji picker open so multiple emojis can be inserted
-            Some("emoji")
+    let keep_open_tab = if UserSettingsManager::new().load().keep_picker_open_after_insert {
+        match item_type.as_deref() {
+            Some("emoji") => {
+                state.emoji_manager.lock().record_usage(&text);
+                // Keep the emoji picker open so multiple emojis can be inserted
+                Some("emoji")
+            }
+            Some("kaomoji") => Some("kaomoji"),
+            Some("symbol") => Some("symbols"),
+            _ => None,
         }
-        Some("kaomoji") => Some("kaomoji"),
-        Some("symbol") => Some("symbols"),
-        _ => None,
+    } else {
+        // Classic behavior: still record emoji usage, but close after paste.
+        if let Some(t) = item_type.as_deref() {
+            if t == "emoji" {
+                state.emoji_manager.lock().record_usage(&text);
+            }
+        }
+        None
     };
 
     // 1. Prepare Environment

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -200,11 +200,16 @@ async fn paste_text(
     let _paste_guard = state.paste_gate.lock().await;
 
     // 0. Record usage if applicable
-    if let Some(t) = item_type.as_deref() {
-        if t == "emoji" {
+    let keep_open_tab = match item_type.as_deref() {
+        Some("emoji") => {
             state.emoji_manager.lock().record_usage(&text);
+            // Keep the emoji picker open so multiple emojis can be inserted
+            Some("emoji")
         }
-    }
+        Some("kaomoji") => Some("kaomoji"),
+        Some("symbol") => Some("symbols"),
+        _ => None,
+    };
 
     // 1. Prepare Environment
     WindowController::hide(&app);
@@ -219,6 +224,14 @@ async fn paste_text(
 
     // 3. Simulate Paste
     simulate_paste_keystroke().map_err(|e| e.to_string())?;
+
+    // 4. Re-open picker for multi-insert (emoji / kaomoji / symbols)
+    if let Some(tab) = keep_open_tab {
+        // Brief pause so the target app can consume the paste keystroke
+        // before we steal focus back to the picker.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        WindowController::show_with_tab(&app, tab);
+    }
 
     Ok(())
 }
@@ -438,6 +451,28 @@ impl WindowController {
                 }
             }
             let _ = window.hide();
+        }
+    }
+
+    /// Show the window (always) and switch to the given tab.
+    /// Used after multi-insert paste so the picker stays available.
+    pub fn show_with_tab(app: &AppHandle, tab: &str) {
+        if STARTED_IN_BACKGROUND.load(Ordering::SeqCst) {
+            INITIAL_SHOW_ALLOWED.store(true, Ordering::SeqCst);
+        }
+
+        if let Some(window) = app.get_webview_window("main") {
+            // Capture the window that just received the paste so the next
+            // paste can restore focus there again.
+            save_focused_window();
+            let _ = app.emit("switch-tab", tab);
+
+            if !window.is_visible().unwrap_or(false) {
+                Self::position_and_show(&window, app);
+            } else {
+                let _ = window.set_focus();
+                let _ = app.emit("window-shown", ());
+            }
         }
     }
 

--- a/src-tauri/src/user_settings.rs
+++ b/src-tauri/src/user_settings.rs
@@ -31,6 +31,12 @@ pub struct UserSettings {
     #[serde(default = "default_true")]
     pub enable_ui_polish: bool,
 
+    /// Keep the emoji/kaomoji/symbol picker open after inserting a character
+    /// so multiple can be inserted in a row. Off by default (classic behavior:
+    /// the window closes after each paste).
+    #[serde(default)]
+    pub keep_picker_open_after_insert: bool,
+
     // --- History Settings ---
     /// Maximum number of clipboard history items to keep (1 to 100000)
     #[serde(default = "default_max_history_size")]
@@ -92,6 +98,7 @@ impl Default for UserSettings {
             enable_dynamic_tray_icon: true,
             enable_smart_actions: true,
             enable_ui_polish: true,
+            keep_picker_open_after_insert: false,
             max_history_size: default_max_history_size(),
             auto_delete_interval: 0,
             auto_delete_unit: "hours".to_string(),

--- a/src/ClipboardApp.tsx
+++ b/src/ClipboardApp.tsx
@@ -22,6 +22,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   light_background_opacity: 0.7,
   enable_smart_actions: true,
   enable_ui_polish: true,
+  keep_picker_open_after_insert: false,
   enable_dynamic_tray_icon: true,
   max_history_size: 50,
   auto_delete_interval: 0,

--- a/src/ClipboardApp.tsx
+++ b/src/ClipboardApp.tsx
@@ -206,9 +206,15 @@ function ClipboardApp() {
       setTimeout(() => {
         const currentTab = activeTabRef.current
 
-        if (currentTab !== 'clipboard') {
-          // Focus the first tab button if on other tabs
-          // Clipboard tab focus is handled inside ClipboardTab component
+        // Picker tabs focus their own grids (emoji/symbols/kaomoji).
+        // Clipboard tab focus is handled inside ClipboardTab.
+        // Only fall back to the tab bar for unknown tabs.
+        if (
+          currentTab !== 'clipboard' &&
+          currentTab !== 'emoji' &&
+          currentTab !== 'symbols' &&
+          currentTab !== 'kaomoji'
+        ) {
           tabBarRef.current?.focusFirstTab()
         }
       }, 100)

--- a/src/ClipboardApp.tsx
+++ b/src/ClipboardApp.tsx
@@ -175,21 +175,46 @@ function ClipboardApp() {
     applyThemeClass(isDark)
   }, [isDark])
 
-  // Handle ESC key to close/hide window
+  // Handle ESC key to close/hide window.
+  // Hide on key *release* (with a fallback timer) so the Escape key-release
+  // event is consumed by this window. Hiding on keydown returns X11 focus to
+  // the app behind us while the key is still held, letting the release leak
+  // into that app (e.g. closing its dialogs).
   useEffect(() => {
-    const handleKeyDown = async (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault()
-        try {
-          await getCurrentWindow().hide()
-        } catch (err) {
-          console.error('Failed to hide window:', err)
-        }
+    let armed = false
+    let fallbackTimer: number | null = null
+
+    const hideWindow = () => {
+      armed = false
+      if (fallbackTimer !== null) {
+        window.clearTimeout(fallbackTimer)
+        fallbackTimer = null
       }
+      getCurrentWindow()
+        .hide()
+        .catch((err) => console.error('Failed to hide window:', err))
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || armed) return
+      e.preventDefault()
+      armed = true
+      // Fallback in case the keyup never reaches us (focus lost mid-press)
+      fallbackTimer = window.setTimeout(hideWindow, 400)
+    }
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || !armed) return
+      hideWindow()
     }
 
     globalThis.addEventListener('keydown', handleKeyDown)
-    return () => globalThis.removeEventListener('keydown', handleKeyDown)
+    globalThis.addEventListener('keyup', handleKeyUp)
+    return () => {
+      globalThis.removeEventListener('keydown', handleKeyDown)
+      globalThis.removeEventListener('keyup', handleKeyUp)
+      if (fallbackTimer !== null) window.clearTimeout(fallbackTimer)
+    }
   }, [])
 
   // Use refs to store current values for the focus handler (to avoid re-registering listener)

--- a/src/SettingsApp.tsx
+++ b/src/SettingsApp.tsx
@@ -20,6 +20,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   light_background_opacity: 0.7,
   enable_smart_actions: true,
   enable_ui_polish: true,
+  keep_picker_open_after_insert: false,
   enable_dynamic_tray_icon: true,
   max_history_size: 50,
   custom_kaomojis: [],

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -1,7 +1,8 @@
-import { useState, useCallback, memo, useRef } from 'react'
+import { useState, useCallback, memo, useRef, useEffect } from 'react'
 import { Grid, useGridRef } from 'react-window'
 import { clsx } from 'clsx'
 import { Clock } from 'lucide-react'
+import { listen } from '@tauri-apps/api/event'
 import { useEmojiPicker } from '../hooks/useEmojiPicker'
 import { SearchBar } from './common/SearchBar'
 import { SectionHeader } from './common/SectionHeader'
@@ -214,6 +215,44 @@ export function EmojiPicker({ isDark, opacity }: EmojiPickerProps) {
     containerRef: recentGridRef,
     dataAttributeName: 'data-recent-index',
   })
+
+  // Focus an emoji cell in the main grid (DOM only; roving tabindex already tracks index)
+  const focusEmojiAt = useCallback((index: number) => {
+    if (filteredEmojis.length === 0) return
+
+    const focusCell = () => {
+      const cell = mainGridContainerRef.current?.querySelector(
+        `[data-main-index="${index}"]`
+      ) as HTMLElement | null
+      cell?.focus()
+    }
+
+    // Wait for virtualized grid cells to mount
+    requestAnimationFrame(() => {
+      focusCell()
+      setTimeout(focusCell, 50)
+    })
+  }, [filteredEmojis.length])
+
+  // Initial mount / after load — focus first emoji so arrows work immediately
+  useEffect(() => {
+    if (isLoading || filteredEmojis.length === 0) return
+    if (dimensions.width <= 0 || dimensions.height <= 0) return
+    // Defer so we don't sync-set state during render/effect (roving index starts at 0)
+    const t = setTimeout(() => focusEmojiAt(0), 0)
+    return () => clearTimeout(t)
+  }, [isLoading, filteredEmojis.length, dimensions.width, dimensions.height, focusEmojiAt])
+
+  // Re-focus grid when the window is shown again (e.g. Super+. or after multi-insert)
+  useEffect(() => {
+    const unlisten = listen('window-shown', () => {
+      setMainFocusedIndex(0)
+      setTimeout(() => focusEmojiAt(0), 80)
+    })
+    return () => {
+      unlisten.then((fn) => fn())
+    }
+  }, [focusEmojiAt])
 
   if (isLoading) {
     return (

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -307,6 +307,29 @@ export function EmojiPicker({ isDark, opacity }: EmojiPickerProps) {
     [searchQuery, handleSearchChange]
   )
 
+  // Keyboard behavior while focus is in the search input:
+  // Enter/Space inserts the highlighted emoji, ArrowDown/ArrowUp move
+  // focus into the grid at the current highlighted cell.
+  const handleSearchKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        if (filteredEmojis.length === 0) return
+        e.preventDefault()
+        setActiveGrid('main')
+        // Wait a tick so the input unmounts nothing / grid is stable
+        setTimeout(() => focusEmojiAt(mainFocusedIndex), 0)
+        return
+      }
+      if (e.key === 'Enter' || e.key === ' ') {
+        if (filteredEmojis.length === 0) return
+        e.preventDefault()
+        const emoji = filteredEmojis[mainFocusedIndex]
+        if (emoji) handleSelect(emoji)
+      }
+    },
+    [filteredEmojis, mainFocusedIndex, focusEmojiAt, handleSelect]
+  )
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-full">
@@ -323,6 +346,7 @@ export function EmojiPicker({ isDark, opacity }: EmojiPickerProps) {
             ref={searchInputRef}
             value={searchQuery}
             onChange={handleSearchChange}
+            onKeyDown={handleSearchKeyDown}
             placeholder="Search emojis..."
             aria-label="Search emojis"
             isDark={isDark}

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -27,6 +27,7 @@ interface EmojiCellProps {
   'data-recent-index'?: number
   onKeyDown?: (e: React.KeyboardEvent) => void
   onItemFocus?: () => void
+  isFocused?: boolean
 }
 
 /** Individual emoji cell - memoized for performance */
@@ -39,6 +40,7 @@ const EmojiCell = memo(function EmojiCell({
   'data-recent-index': recentIndex,
   onKeyDown,
   onItemFocus,
+  isFocused = false,
 }: EmojiCellProps) {
   return (
     <button
@@ -60,7 +62,11 @@ const EmojiCell = memo(function EmojiCell({
         'rounded-md transition-transform duration-100',
         'hover:bg-win11Light-bg-tertiary dark:hover:bg-win11-bg-card-hover',
         'hover:scale-110 transform-gpu hover:will-change-transform',
-        'focus:outline-none focus-visible:ring-2 focus-visible:ring-win11-bg-accent'
+        'focus:outline-none',
+        // Roving-focus indicator is state-driven (not :focus-visible) so it
+        // persists after programmatic focus (e.g. re-focus after paste).
+        isFocused &&
+          'ring-2 ring-win11-bg-accent bg-win11Light-bg-tertiary dark:bg-win11-bg-card-hover'
       )}
       title={emoji.name}
       aria-label={emoji.name}
@@ -75,6 +81,8 @@ interface EmojiGridData {
   onSelect: (emoji: Emoji) => void
   onHover: (emoji: Emoji | null) => void
   focusedIndex: number
+  /** Whether the main grid currently owns the visible roving-focus ring */
+  ringActive: boolean
   onKeyDown: (e: React.KeyboardEvent, index: number) => void
   onItemFocus: (index: number) => void
   columnCount: number
@@ -89,6 +97,7 @@ function EmojiGridCell({
   onSelect,
   onHover,
   focusedIndex,
+  ringActive,
   onKeyDown,
   onItemFocus,
   columnCount,
@@ -125,6 +134,7 @@ function EmojiGridCell({
         onSelect={onSelect}
         onHover={onHover}
         tabIndex={isFocused ? 0 : -1}
+        isFocused={ringActive && isFocused}
         data-main-index={index}
         onKeyDown={(e) => onKeyDown(e, index)}
         onItemFocus={() => onItemFocus(index)}
@@ -163,6 +173,10 @@ export function EmojiPicker({ isDark, opacity }: EmojiPickerProps) {
   const [recentFocusedIndex, setRecentFocusedIndex] = useState(0)
   const [mainFocusedIndex, setMainFocusedIndex] = useState(0)
   const [categoryFocusedIndex, setCategoryFocusedIndex] = useState(0)
+  // Which grid owns the visible roving-focus indicator
+  const [activeGrid, setActiveGrid] = useState<'main' | 'recent'>('main')
+
+  const searchInputRef = useRef<HTMLInputElement>(null)
 
   const handleSearchChange = useCallback(
     (val: string) => {
@@ -247,12 +261,30 @@ export function EmojiPicker({ isDark, opacity }: EmojiPickerProps) {
   useEffect(() => {
     const unlisten = listen('window-shown', () => {
       setMainFocusedIndex(0)
+      setActiveGrid('main')
       setTimeout(() => focusEmojiAt(0), 80)
     })
     return () => {
       unlisten.then((fn) => fn())
     }
   }, [focusEmojiAt])
+
+  // Type-ahead: typing a printable char anywhere (except inputs) jumps to search
+  const handleTypeAhead = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.ctrlKey || e.metaKey || e.altKey) return
+      if (e.key.length !== 1 || e.key === ' ') return
+      const target = e.target as HTMLElement
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') return
+
+      // Prevent the char from landing elsewhere; add it to the query and
+      // move focus to the search input so subsequent typing works natively.
+      e.preventDefault()
+      handleSearchChange(searchQuery + e.key)
+      searchInputRef.current?.focus()
+    },
+    [searchQuery, handleSearchChange]
+  )
 
   if (isLoading) {
     return (
@@ -263,17 +295,19 @@ export function EmojiPicker({ isDark, opacity }: EmojiPickerProps) {
   }
 
   return (
-    <PickerLayout
-      header={
-        <SearchBar
-          value={searchQuery}
-          onChange={handleSearchChange}
-          placeholder="Search emojis..."
-          aria-label="Search emojis"
-          isDark={isDark}
-          opacity={opacity}
-        />
-      }
+    <div className="h-full" onKeyDown={handleTypeAhead}>
+      <PickerLayout
+        header={
+          <SearchBar
+            ref={searchInputRef}
+            value={searchQuery}
+            onChange={handleSearchChange}
+            placeholder="Search emojis..."
+            aria-label="Search emojis"
+            isDark={isDark}
+            opacity={opacity}
+          />
+        }
       subHeader={
         <>
           {/* Recent emojis (only show when not searching) */}
@@ -295,9 +329,13 @@ export function EmojiPicker({ isDark, opacity }: EmojiPickerProps) {
                       onSelect={handleSelect}
                       onHover={setHoveredEmoji}
                       tabIndex={index === recentFocusedIndex ? 0 : -1}
+                      isFocused={activeGrid === 'recent' && index === recentFocusedIndex}
                       data-recent-index={index}
                       onKeyDown={(e) => handleRecentKeyDown(e, index)}
-                      onItemFocus={() => setRecentFocusedIndex(index)}
+                      onItemFocus={() => {
+                        setActiveGrid('recent')
+                        setRecentFocusedIndex(index)
+                      }}
                     />
                   </div>
                 ))}
@@ -366,8 +404,12 @@ export function EmojiPicker({ isDark, opacity }: EmojiPickerProps) {
                   onSelect: handleSelect,
                   onHover: setHoveredEmoji,
                   focusedIndex: mainFocusedIndex,
+                  ringActive: activeGrid === 'main',
                   onKeyDown: handleMainGridKeyDown,
-                  onItemFocus: setMainFocusedIndex,
+                  onItemFocus: (index: number) => {
+                    setActiveGrid('main')
+                    setMainFocusedIndex(index)
+                  },
                   columnCount,
                   columnWidth,
                 }}
@@ -376,7 +418,8 @@ export function EmojiPicker({ isDark, opacity }: EmojiPickerProps) {
             </div>
           )
         )}
-      </div>
-    </PickerLayout>
+        </div>
+      </PickerLayout>
+    </div>
   )
 }

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -252,10 +252,20 @@ export function EmojiPicker({ isDark, opacity }: EmojiPickerProps) {
   useEffect(() => {
     if (isLoading || filteredEmojis.length === 0) return
     if (dimensions.width <= 0 || dimensions.height <= 0) return
+    // While searching, the search input owns focus — don't steal it back
+    // (e.g. every backspace would otherwise re-focus the grid).
+    if (searchQuery) return
     // Defer so we don't sync-set state during render/effect (roving index starts at 0)
     const t = setTimeout(() => focusEmojiAt(0), 0)
     return () => clearTimeout(t)
-  }, [isLoading, filteredEmojis.length, dimensions.width, dimensions.height, focusEmojiAt])
+  }, [
+    isLoading,
+    filteredEmojis.length,
+    dimensions.width,
+    dimensions.height,
+    searchQuery,
+    focusEmojiAt,
+  ])
 
   // Re-focus grid when the window is shown again (e.g. Super+. or after multi-insert)
   useEffect(() => {
@@ -269,13 +279,24 @@ export function EmojiPicker({ isDark, opacity }: EmojiPickerProps) {
     }
   }, [focusEmojiAt])
 
-  // Type-ahead: typing a printable char anywhere (except inputs) jumps to search
+  // Type-ahead: typing a printable char anywhere (except inputs) jumps to search.
+  // Backspace likewise edits the query when focus is outside the input.
   const handleTypeAhead = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.ctrlKey || e.metaKey || e.altKey) return
-      if (e.key.length !== 1 || e.key === ' ') return
       const target = e.target as HTMLElement
-      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') return
+      const inInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA'
+
+      if (e.key === 'Backspace') {
+        if (inInput || !searchQuery) return
+        e.preventDefault()
+        handleSearchChange(searchQuery.slice(0, -1))
+        searchInputRef.current?.focus()
+        return
+      }
+
+      if (e.key.length !== 1 || e.key === ' ') return
+      if (inInput) return
 
       // Prevent the char from landing elsewhere; add it to the query and
       // move focus to the search input so subsequent typing works natively.

--- a/src/components/FeaturesSection.tsx
+++ b/src/components/FeaturesSection.tsx
@@ -44,10 +44,12 @@ export function FeaturesSection({
       </div>
       <div className="p-6 space-y-6">
         {FEATURES.map((feature) => (
-          <div key={feature.key} className="flex items-center justify-between">
-            <div>
+          <div key={feature.key} className="flex items-center justify-between gap-4">
+            <div className="min-w-0">
               <div className="text-sm font-medium">{feature.label}</div>
-              <div className={clsx('text-xs', isDark ? 'text-gray-400' : 'text-gray-500')}>
+              <div
+                className={clsx('text-xs', isDark ? 'text-gray-400' : 'text-gray-500')}
+              >
                 {feature.desc}
               </div>
             </div>

--- a/src/components/FeaturesSection.tsx
+++ b/src/components/FeaturesSection.tsx
@@ -13,6 +13,11 @@ const FEATURES = [
     label: 'UI Polish',
     desc: 'Enable animations and compact mode support.',
   },
+  {
+    key: 'keep_picker_open_after_insert',
+    label: 'Keep Picker Open After Insert',
+    desc: 'Keep the emoji/kaomoji/symbol picker open after inserting, so you can insert multiple in a row.',
+  },
 ] as const
 
 export function FeaturesSection({

--- a/src/components/KaomojiPicker.tsx
+++ b/src/components/KaomojiPicker.tsx
@@ -55,7 +55,7 @@ export function KaomojiPicker({ isDark, opacity, customKaomojis = [] }: KaomojiP
 
   const handlePaste = useCallback(async (text: string) => {
     try {
-      await invoke('paste_text', { text })
+      await invoke('paste_text', { text, itemType: 'kaomoji' })
     } catch (err) {
       console.error('Failed to paste kaomoji', err)
     }

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -13,7 +13,7 @@ export function Switch({
     <button
       onClick={() => onChange(!checked)}
       className={clsx(
-        'relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-win11-bg-accent focus:ring-offset-2',
+        'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-win11-bg-accent focus:ring-offset-2',
         checked ? 'bg-win11-bg-accent' : isDark ? 'bg-white/10' : 'bg-gray-300',
         isDark ? 'focus:ring-offset-gray-900' : 'focus:ring-offset-white'
       )}

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -14,6 +14,7 @@ export interface SearchBarProps {
   opacity: number
   isRegex?: boolean
   onToggleRegex?: () => void
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void
 }
 
 export const SearchBar = memo(
@@ -29,6 +30,7 @@ export const SearchBar = memo(
       opacity,
       isRegex = false,
       onToggleRegex,
+      onKeyDown,
     },
     ref
   ) {
@@ -51,6 +53,7 @@ export const SearchBar = memo(
           type="text"
           value={value}
           onChange={(e) => onChange(e.target.value)}
+          onKeyDown={onKeyDown}
           placeholder={placeholder}
           aria-label={ariaLabel ?? placeholder}
           className={clsx(

--- a/src/hooks/useSymbolPicker.ts
+++ b/src/hooks/useSymbolPicker.ts
@@ -36,7 +36,7 @@ export function useSymbolPicker() {
   const pasteSymbol = useCallback(async (symbol: SymbolItem) => {
     try {
       // Use the generic paste_text command
-      await invoke('paste_text', { text: symbol.char })
+      await invoke('paste_text', { text: symbol.char, itemType: 'symbol' })
 
       // Update recent
       setRecentSymbols((prev) => {

--- a/src/types/clipboard.ts
+++ b/src/types/clipboard.ts
@@ -71,6 +71,8 @@ export interface UserSettings {
   enable_smart_actions: boolean
   enable_ui_polish: boolean
   enable_dynamic_tray_icon: boolean
+  /** Keep the emoji/kaomoji/symbol picker open after insert (multi-insert) */
+  keep_picker_open_after_insert: boolean
   max_history_size: number
   auto_delete_interval: number
   auto_delete_unit: 'minutes' | 'hours' | 'days' | 'weeks'


### PR DESCRIPTION
## Summary
- Focus the first emoji in the grid when the emoji picker opens (`--emoji` / Super+.), so arrow keys navigate the grid immediately instead of requiring Tab through the tab bar.
- Keep the picker open after inserting an emoji (and kaomoji/symbol) so multiple characters can be inserted in one session. Clipboard history paste still closes as before.

## Changes
- `EmojiPicker.tsx`: focus first grid cell on mount and on `window-shown`
- `ClipboardApp.tsx`: stop stealing focus to the tab bar for picker tabs
- `main.rs` `paste_text`: after emoji/kaomoji/symbol paste, re-show picker via `show_with_tab`
- Pass `itemType` from kaomoji/symbol paste callers


- Added a new option (disabled by default, no braking change on experience)
<img width="452" height="298" alt="image" src="https://github.com/user-attachments/assets/58555104-edd3-4886-bb39-f808ebde7a69" />

- Allows inserting multiple emojis at once. _(`ESC` closes immediately)_
<img width="647" height="694" alt="Peek 2026-08-31 11-52" src="https://github.com/user-attachments/assets/9fd5c2fe-16fd-47d1-8d1e-3748f49f5645" />

Also direct searching without using mouse is implemented.

## Summary by Sourcery

Improve picker focus management and optionally keep character pickers open for consecutive inserts.

New Features:
- Add an optional setting to keep the emoji, kaomoji, and symbol picker open for multi-insert workflows.
- Focus the emoji grid when the picker opens and improve keyboard navigation and search interactions.

Bug Fixes:
- Prevent Escape key release events from leaking to the previously focused application.
- Preserve clipboard history behavior while supporting picker reopening after character insertion.

Enhancements:
- Keep picker tabs from redirecting focus to the tab bar and restore picker focus after reopening.

## Summary by Sourcery

Improve character picker keyboard workflows and support optional multi-insert sessions.

New Features:
- Add an opt-in setting to keep emoji, kaomoji, and symbol pickers open for consecutive inserts.
- Enable direct keyboard search and immediate grid navigation when opening the emoji picker.

Bug Fixes:
- Prevent Escape key-release events from reaching the previously focused application.
- Preserve clipboard history closing behavior while reopening character pickers only when multi-insert is enabled.

Enhancements:
- Improve picker focus restoration and visual focus management across grid navigation and reopening.